### PR TITLE
Add "Quit" submenu item to Linux and Windows custom menu #64

### DIFF
--- a/main.js
+++ b/main.js
@@ -255,5 +255,16 @@ const pjson = require('./package.json');
       }
     );
   }
+  const quitSubmenu =
+    {
+      label: "Quit",
+      click: () => {
+        app.quit();
+      }
+    }
+  if (process.platform != 'darwin')
+  {
+    template[0].submenu.push(quitSubmenu);
+  }
   return template;
 }

--- a/main.js
+++ b/main.js
@@ -261,9 +261,8 @@ const pjson = require('./package.json');
       click: () => {
         app.quit();
       }
-    }
-  if (process.platform != 'darwin')
-  {
+    };
+  if (process.platform != 'darwin') {
     template[0].submenu.push(quitSubmenu);
   }
   return template;


### PR DESCRIPTION
  * Added to "File" menu item.
  * Excludes the Darwin/OS X platform.
  * Addresses issue https://github.com/nexB/aboutcode-manager/issues/64

Signed-off-by: John M. Horan <johnmhoran@gmail.com>