### PR TITLE
Modify build.sh and README build instructions #110

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,16 +60,16 @@ npm start
 
 ## Release instructions
 
-Build `dist` target:
+You can build a `dist` directory containing executables for any one of three target platforms by running `./build.sh <target>` and replacing `<target>` with `linux`, `darwin` or `win32` (for Linux, Darwin/MacOS and Windows, respectively).  A build targeting Windows, for example, would look like this:
 
 ```bash
-$ ./build.sh
+$ ./build.sh win32
 ```
 
 After building is done, you can find `AboutCode-Manager` under `dist/AboutCode-Manager-<os>-x64-<version>`.
 Archives (tar.gz and .zip) are also built.
 
-Note: A build for any of the three target platforms (Darwin/MacOS, Linux and Windows) must be executed on the targeted platform.
+Note: A build for any of the three target platforms must be executed on the targeted platform.  
 
 ## Testing
 

--- a/build.sh
+++ b/build.sh
@@ -17,6 +17,9 @@ fi
 if [ "$PLATFORM" == "darwin" ]; then
     ICON="mac/aboutcode.icns"
 fi
+if [ "$PLATFORM" == "win32" ]; then
+    ICON="win/aboutcode_256x256.ico"
+fi
 
 echo '=> BUILDING AboutCode App release'
 


### PR DESCRIPTION
  * Added Windows platform to the build.sh file.
  * Modified README build instructions to incorporate Windows platform
    and other recent changes to build.sh.

Signed-off-by: John M. Horan <johnmhoran@gmail.com>