### PR TITLE
No-components alert when importing to DejaCode#40

### DIFF
--- a/assets/js/componentDataTables.js
+++ b/assets/js/componentDataTables.js
@@ -18,13 +18,6 @@ class ComponentDataTable {
     constructor(tableID, aboutCodeDB) {
         this.aboutCodeDB = aboutCodeDB;
         this.dataTable = this._createDataTable(tableID);
-        this.dataTable.buttons().container().attr({
-            "id": "show-components",
-            "data-toggle": "modal",
-            "data-placement": "right",
-            "title": "Upload Components to DejaCode",
-            "data-target": "#componentExportModal"
-        });
     }
 
     database(aboutCodeDB) {
@@ -49,7 +42,16 @@ class ComponentDataTable {
             "<'row'<'col-sm-5'i><'col-sm-7'p>>",
             buttons: [{
                 name: "uploadDeja",
-                text: '<i class=" fa fa-cloud-upload"></i> Upload Components'
+                text: '<i class=" fa fa-cloud-upload"></i> Upload Components',
+                action: function ( e, dt, node, config ) {
+                    var entryCount = dt.data().count();
+                    if (entryCount > 0) {
+                        $('#componentExportModal').modal('show');
+                    }
+                    else {
+                        alert("You have no Components to upload.  \n\nPlease create at least one Component and try again.");
+                    }
+                }
             }],
             "language": {
                 "emptyTable": "No Components created."

--- a/assets/js/componentDataTables.js
+++ b/assets/js/componentDataTables.js
@@ -43,14 +43,16 @@ class ComponentDataTable {
             buttons: [{
                 name: "uploadDeja",
                 text: '<i class=" fa fa-cloud-upload"></i> Upload Components',
-                action: function ( e, dt, node, config ) {
-                    var entryCount = dt.data().count();
-                    if (entryCount > 0) {
-                        $('#componentExportModal').modal('show');
-                    }
-                    else {
-                        alert("You have no Components to upload.  \n\nPlease create at least one Component and try again.");
-                    }
+                action: ( e, dt, node, config ) => {
+                    this.aboutCodeDB.findAllComponents( {} )
+                        .then((components) => {
+                            if (components.length > 0) {
+                                $('#componentExportModal').modal('show');
+                            }
+                            else {
+                                alert("You have no Components to upload.  \n\nPlease create at least one Component and try again.");
+                            }
+                        });
                 }
             }],
             "language": {

--- a/assets/js/componentDataTables.js
+++ b/assets/js/componentDataTables.js
@@ -48,8 +48,7 @@ class ComponentDataTable {
                         .then((components) => {
                             if (components.length > 0) {
                                 $('#componentExportModal').modal('show');
-                            }
-                            else {
+                            } else {
                                 alert("You have no Components to upload.  \n\nPlease create at least one Component and try again.");
                             }
                         });


### PR DESCRIPTION
  * Deleted button definition (including modal trigger) in
    `componentDataTables.js` constructor.
  * Button action function added to button definition in
    `_createDataTable(tableID)`, including
    * count based on DataTable parameter `dt` and
    * if/then test to trigger “Upload Components to DejaCode” modal.
  * Next step: modify to base test on `Component` table in `AboutCodeDB`
    rather than DataTable.

Signed-off-by: John M. Horan <johnmhoran@gmail.com>