### PR TITLE
Add ability to resize the views #21

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -158,7 +158,7 @@ div.node-content {
   overflow-y: scroll;
   height: 100%;
   margin: 0 0 0 10px;
-  padding-top: 40px;
+  padding-top: 15px;
   background-color: #f9f9f9;
 }
 
@@ -316,5 +316,15 @@ html, body {
 .gutter.gutter-horizontal {
   height: 100%;
   float: left;
+}
+
+.div-hide {
+  display: none;
+  visibility: hidden;
+}
+
+.div-show {
+  display: block;
+  visibility: visible;
 }
 /* end of split.js-related CSS */

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -300,13 +300,11 @@ html, body {
   background-position: 50%;
 }
 
-.gutter.gutter-horizontal {
-  background-image: url('../../node_modules/split.js/grips/vertical.png');
+ .gutter.gutter-horizontal {
   cursor: ew-resize;
 }
 
 .gutter.gutter-vertical {
-  background-image: url('../../node_modules/split.js/grips/horizontal.png');
   cursor: ns-resize;
 }
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -156,7 +156,7 @@ div.node-content {
   min-height: 100px;
   overflow-x: scroll;
   overflow-y: scroll;
-  height: 600px;
+  height: 100%;
   margin: 0 0 0 10px;
   padding-top: 40px;
   background-color: #f9f9f9;
@@ -275,3 +275,46 @@ div.dataTables_scrollHead th:first-child {
 .fa_custom {
   color: #3498db;
 }
+
+/* This set of CSS is required for the split.js splitter/resizing functionality */
+
+.root-div {
+  height: 100%;
+  /* This removes the unwanted horizontal scrollbar. */
+  margin: 0;
+}
+
+html, body {
+  height: 100%;
+  margin: 0;
+}
+
+#sidebar-div {
+  height: 100%;
+  border: 0;
+  width: 100px;
+  max-width: 100px;
+}
+
+.gutter {
+  background-color: #e8e8e8;
+  background-repeat: no-repeat;
+  background-position: 50%;
+}
+
+.gutter.gutter-horizontal {
+  background-image: url('../../node_modules/split.js/grips/vertical.png');
+  cursor: ew-resize;
+}
+
+.gutter.gutter-vertical {
+  background-image: url('../../node_modules/split.js/grips/horizontal.png');
+  cursor: ns-resize;
+}
+
+.split.split-horizontal,
+.gutter.gutter-horizontal {
+  height: 100%;
+  float: left;
+}
+/* end of split.js-related CSS */

--- a/assets/js/renderer.js
+++ b/assets/js/renderer.js
@@ -388,50 +388,30 @@ $(document).ready(function () {
     // Center and reset node view
     resetZoomButton.click(() => nodeView.centerNode());
 
-    // Clear any saved splitter-related div widths from local storage when the app closes.
-    const clearDivs = () => {
-        if ('localStorage' in window && window['localStorage'] !== null) {
-            localStorage.removeItem('splitSizes');
-        }
-    }
-
-    window.addEventListener('beforeunload', function (event) {
-        clearDivs();
-    });
-
-    // Used in the split.js onDragEnd property below.
-    const saveResize = () => {
-        localStorage.setItem('splitSizes', JSON.stringify(instance.getSizes()));
-    }
-
     // Instantiate the splitter.
-    const instance = Split(['#leftCol', '#tabbar'], {
+    const splitter = Split(['#leftCol', '#tabbar'], {
         sizes: [18, 76],
         minSize: 200,
         gutterSize: 5,
-        onDragEnd: saveResize
+        onDragEnd: function() {
+            sessionStorage.setItem('splitSizes', JSON.stringify(splitter.getSizes()));
+        }
     });
 
-    // Retrieve any saved resize settings from localStorage or else use our default setting.
-    function getDivs() {
-        if (localStorage.getItem('splitSizes')) {
-            var dataSet;
-            try {
-                dataSet = JSON.parse(localStorage.getItem('splitSizes')) || [];
-            } catch (err) {
-                dataSet = [];
-            }
-            var key_firstDiv = dataSet[0];
-            var key_secondDiv = dataSet[1];
-            instance.setSizes([key_firstDiv, key_secondDiv]);
-        } else {
-            instance.setSizes([18, 76]);
+    // Retrieve any saved resize settings from sessionStorage or else use our default setting.
+    function restoreSplitterSizes() {
+        let splitSizes;
+        try {
+            splitSizes = JSON.parse(sessionStorage.getItem('splitSizes')) || [18, 76];
+        } catch (err) {
+            console.log(err);
         }
+        splitter.setSizes(splitSizes);
     }
 
     // Show Table View (aka "clue DataTable").  Hide node view and component summary table.
     function showTableView() {
-        getDivs();
+        restoreSplitterSizes();
         $(".gutter-horizontal").removeClass("div-hide").addClass("div-show");
         cluesContainer.show();
         nodeContainer.hide();
@@ -450,7 +430,7 @@ $(document).ready(function () {
 
     // Show node view. Hide clue and component table
     function showNodeView() {
-        getDivs();
+        restoreSplitterSizes();
         $(".gutter-horizontal").removeClass("div-hide").addClass("div-show");
         nodeContainer.show();
         cluesContainer.hide();
@@ -470,7 +450,7 @@ $(document).ready(function () {
     // Show component summary table. Hide DataTable and node view
     function showComponentSummaryView() {
         $(".gutter-horizontal ").removeClass("div-show").addClass("div-hide");
-        instance.setSizes([3, 91]);
+        splitter.setSizes([3, 91]);
         componentContainer.show();
         nodeContainer.hide();
         cluesContainer.hide();

--- a/assets/js/renderer.js
+++ b/assets/js/renderer.js
@@ -395,6 +395,7 @@ $(document).ready(function () {
         gutterSize: 5,
         onDragEnd: function() {
             sessionStorage.setItem('splitSizes', JSON.stringify(splitter.getSizes()));
+            barChart.draw();
         }
     });
 

--- a/assets/js/renderer.js
+++ b/assets/js/renderer.js
@@ -355,8 +355,51 @@ $(document).ready(function () {
     // Center and reset node view
     resetZoomButton.click(() => nodeView.centerNode());
 
+    // Clear any saved splitter-related div widths from local storage when the app closes.
+    const clearDivs = () => {
+        if ('localStorage' in window && window['localStorage'] !== null) {
+            localStorage.removeItem('splitSizes');
+        }
+    }
+
+    window.addEventListener('beforeunload', function (event) {
+        clearDivs();
+    });
+
+    // Used in the split.js onDragEnd property below.
+    const saveResize = () => {
+        localStorage.setItem('splitSizes', JSON.stringify(instance.getSizes()));
+    }
+
+    // Instantiate the splitter.
+    const instance = Split(['#leftCol', '#tabbar'], {
+        sizes: [18, 76],
+        minSize: 200,
+        gutterSize: 5,
+        onDragEnd: saveResize
+    });
+
+    // Retrieve any saved resize settings from localStorage or else use our default setting.
+    function getDivs() {
+        if (localStorage.getItem('splitSizes')) {
+            var dataSet;
+            try {
+                dataSet = JSON.parse(localStorage.getItem('splitSizes')) || [];
+            } catch (err) {
+                dataSet = [];
+            }
+            var key_firstDiv = dataSet[0];
+            var key_secondDiv = dataSet[1];
+            instance.setSizes([key_firstDiv, key_secondDiv]);
+        } else {
+            instance.setSizes([18, 76]);
+        }
+    }
+
     // Show Table View (aka "clue DataTable").  Hide node view and component summary table.
     function showTableView() {
+        getDivs();
+        $(".gutter-horizontal").removeClass("div-hide").addClass("div-show");
         cluesContainer.show();
         nodeContainer.hide();
         componentContainer.hide();
@@ -373,6 +416,8 @@ $(document).ready(function () {
 
     // Show node view. Hide clue and component table
     function showNodeView() {
+        getDivs();
+        $(".gutter-horizontal").removeClass("div-hide").addClass("div-show");
         nodeContainer.show();
         cluesContainer.hide();
         componentContainer.hide();
@@ -389,6 +434,8 @@ $(document).ready(function () {
 
     // Show component summary table. Hide DataTable and node view
     function showComponentSummaryView() {
+        $(".gutter-horizontal ").removeClass("div-show").addClass("div-hide");
+        instance.setSizes([3, 91]);
         componentContainer.show();
         nodeContainer.hide();
         cluesContainer.hide();
@@ -673,13 +720,6 @@ $(document).ready(function () {
                 uploadComponents( apiUrl, dejaCodeComponents, apiKey);
             });
         $("#componentExportModal").modal("hide");
-    });
-
-    // Handles the splitter in index.html between the jsTree and the views on the right.
-    Split(['#leftCol', '#tabbar'], {
-        sizes: [18, 76],
-        minSize: 200,
-        gutterSize: 5
     });
 
 });

--- a/assets/js/renderer.js
+++ b/assets/js/renderer.js
@@ -395,7 +395,9 @@ $(document).ready(function () {
         gutterSize: 5,
         onDragEnd: function() {
             sessionStorage.setItem('splitSizes', JSON.stringify(splitter.getSizes()));
-            barChart.draw();
+            if ($('#bar-chart-container').is(':visible')) {
+                barChart.draw();
+            }
         }
     });
 

--- a/assets/js/renderer.js
+++ b/assets/js/renderer.js
@@ -674,4 +674,12 @@ $(document).ready(function () {
             });
         $("#componentExportModal").modal("hide");
     });
+
+    // Handles the splitter in index.html between the jsTree and the views on the right.
+    Split(['#leftCol', '#tabbar'], {
+        sizes: [18, 76],
+        minSize: 200,
+        gutterSize: 5
+    });
+
 });

--- a/assets/js/renderer.js
+++ b/assets/js/renderer.js
@@ -400,9 +400,9 @@ $(document).ready(function () {
 
     // Retrieve any saved resize settings from sessionStorage or else use our default setting.
     function restoreSplitterSizes() {
-        let splitSizes;
+        let splitSizes = [18, 76];
         try {
-            splitSizes = JSON.parse(sessionStorage.getItem('splitSizes')) || [18, 76];
+            splitSizes = JSON.parse(sessionStorage.getItem('splitSizes')) || splitSizes;
         } catch (err) {
             console.log(err);
         }
@@ -468,6 +468,8 @@ $(document).ready(function () {
 
     // Show bar chart table. Hide other views
     function showBarChartView() {
+        restoreSplitterSizes();
+        $(".gutter-horizontal").removeClass("div-hide").addClass("div-show");
         barChartContainer.show();
         componentContainer.hide();
         nodeContainer.hide();
@@ -763,5 +765,7 @@ $(document).ready(function () {
             $("#componentExportModal").modal("hide");
         }
     });
+
+    restoreSplitterSizes();
 
 });

--- a/assets/js/split.ABOUT
+++ b/assets/js/split.ABOUT
@@ -1,0 +1,12 @@
+about_resource: split.js
+download_url: https://github.com/nathancahill/Split.js/tree/v1.3.5
+version: 1.3.5
+
+name: Split.js
+description: A lightweight utility for creating adjustable split views.
+home_url: https://github.com/nathancahill/Split.js#readme
+owner: Nathan Cahill
+contact: nathan@nathancahill.com
+dje_license: mit
+license_text_file: split.LICENSE
+copyright: Copyright (c) 2017 Nathan Cahill

--- a/assets/js/split.LICENSE
+++ b/assets/js/split.LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2017 Nathan Cahill
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/assets/js/split.js
+++ b/assets/js/split.js
@@ -1,0 +1,536 @@
+/*! Split.js - v1.3.5 */
+
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(global.Split = factory());
+}(this, (function () { 'use strict';
+
+// The programming goals of Split.js are to deliver readable, understandable and
+// maintainable code, while at the same time manually optimizing for tiny minified file size,
+// browser compatibility without additional requirements, graceful fallback (IE8 is supported)
+// and very few assumptions about the user's page layout.
+var global = window;
+var document = global.document;
+
+// Save a couple long function names that are used frequently.
+// This optimization saves around 400 bytes.
+var addEventListener = 'addEventListener';
+var removeEventListener = 'removeEventListener';
+var getBoundingClientRect = 'getBoundingClientRect';
+var NOOP = function () { return false; };
+
+// Figure out if we're in IE8 or not. IE8 will still render correctly,
+// but will be static instead of draggable.
+var isIE8 = global.attachEvent && !global[addEventListener];
+
+// This library only needs two helper functions:
+//
+// The first determines which prefixes of CSS calc we need.
+// We only need to do this once on startup, when this anonymous function is called.
+//
+// Tests -webkit, -moz and -o prefixes. Modified from StackOverflow:
+// http://stackoverflow.com/questions/16625140/js-feature-detection-to-detect-the-usage-of-webkit-calc-over-calc/16625167#16625167
+var calc = (['', '-webkit-', '-moz-', '-o-'].filter(function (prefix) {
+    var el = document.createElement('div');
+    el.style.cssText = "width:" + prefix + "calc(9px)";
+
+    return (!!el.style.length)
+}).shift()) + "calc";
+
+// The second helper function allows elements and string selectors to be used
+// interchangeably. In either case an element is returned. This allows us to
+// do `Split([elem1, elem2])` as well as `Split(['#id1', '#id2'])`.
+var elementOrSelector = function (el) {
+    if (typeof el === 'string' || el instanceof String) {
+        return document.querySelector(el)
+    }
+
+    return el
+};
+
+// The main function to initialize a split. Split.js thinks about each pair
+// of elements as an independant pair. Dragging the gutter between two elements
+// only changes the dimensions of elements in that pair. This is key to understanding
+// how the following functions operate, since each function is bound to a pair.
+//
+// A pair object is shaped like this:
+//
+// {
+//     a: DOM element,
+//     b: DOM element,
+//     aMin: Number,
+//     bMin: Number,
+//     dragging: Boolean,
+//     parent: DOM element,
+//     isFirst: Boolean,
+//     isLast: Boolean,
+//     direction: 'horizontal' | 'vertical'
+// }
+//
+// The basic sequence:
+//
+// 1. Set defaults to something sane. `options` doesn't have to be passed at all.
+// 2. Initialize a bunch of strings based on the direction we're splitting.
+//    A lot of the behavior in the rest of the library is paramatized down to
+//    rely on CSS strings and classes.
+// 3. Define the dragging helper functions, and a few helpers to go with them.
+// 4. Loop through the elements while pairing them off. Every pair gets an
+//    `pair` object, a gutter, and special isFirst/isLast properties.
+// 5. Actually size the pair elements, insert gutters and attach event listeners.
+var Split = function (ids, options) {
+    if ( options === void 0 ) options = {};
+
+    var dimension;
+    var clientDimension;
+    var clientAxis;
+    var position;
+    var paddingA;
+    var paddingB;
+    var elements;
+
+    // All DOM elements in the split should have a common parent. We can grab
+    // the first elements parent and hope users read the docs because the
+    // behavior will be whacky otherwise.
+    var parent = elementOrSelector(ids[0]).parentNode;
+    var parentFlexDirection = global.getComputedStyle(parent).flexDirection;
+
+    // Set default options.sizes to equal percentages of the parent element.
+    var sizes = options.sizes || ids.map(function () { return 100 / ids.length; });
+
+    // Standardize minSize to an array if it isn't already. This allows minSize
+    // to be passed as a number.
+    var minSize = options.minSize !== undefined ? options.minSize : 100;
+    var minSizes = Array.isArray(minSize) ? minSize : ids.map(function () { return minSize; });
+    var gutterSize = options.gutterSize !== undefined ? options.gutterSize : 10;
+    var snapOffset = options.snapOffset !== undefined ? options.snapOffset : 30;
+    var direction = options.direction || 'horizontal';
+    var cursor = options.cursor || (direction === 'horizontal' ? 'ew-resize' : 'ns-resize');
+    var gutter = options.gutter || (function (i, gutterDirection) {
+        var gut = document.createElement('div');
+        gut.className = "gutter gutter-" + gutterDirection;
+        return gut
+    });
+    var elementStyle = options.elementStyle || (function (dim, size, gutSize) {
+        var style = {};
+
+        if (typeof size !== 'string' && !(size instanceof String)) {
+            if (!isIE8) {
+                style[dim] = calc + "(" + size + "% - " + gutSize + "px)";
+            } else {
+                style[dim] = size + "%";
+            }
+        } else {
+            style[dim] = size;
+        }
+
+        return style
+    });
+    var gutterStyle = options.gutterStyle || (function (dim, gutSize) { return (( obj = {}, obj[dim] = (gutSize + "px"), obj ))
+        var obj; });
+
+    // 2. Initialize a bunch of strings based on the direction we're splitting.
+    // A lot of the behavior in the rest of the library is paramatized down to
+    // rely on CSS strings and classes.
+    if (direction === 'horizontal') {
+        dimension = 'width';
+        clientDimension = 'clientWidth';
+        clientAxis = 'clientX';
+        position = 'left';
+        paddingA = 'paddingLeft';
+        paddingB = 'paddingRight';
+    } else if (direction === 'vertical') {
+        dimension = 'height';
+        clientDimension = 'clientHeight';
+        clientAxis = 'clientY';
+        position = 'top';
+        paddingA = 'paddingTop';
+        paddingB = 'paddingBottom';
+    }
+
+    // 3. Define the dragging helper functions, and a few helpers to go with them.
+    // Each helper is bound to a pair object that contains it's metadata. This
+    // also makes it easy to store references to listeners that that will be
+    // added and removed.
+    //
+    // Even though there are no other functions contained in them, aliasing
+    // this to self saves 50 bytes or so since it's used so frequently.
+    //
+    // The pair object saves metadata like dragging state, position and
+    // event listener references.
+
+    function setElementSize (el, size, gutSize) {
+        // Split.js allows setting sizes via numbers (ideally), or if you must,
+        // by string, like '300px'. This is less than ideal, because it breaks
+        // the fluid layout that `calc(% - px)` provides. You're on your own if you do that,
+        // make sure you calculate the gutter size by hand.
+        var style = elementStyle(dimension, size, gutSize);
+
+        // eslint-disable-next-line no-param-reassign
+        Object.keys(style).forEach(function (prop) { return (el.style[prop] = style[prop]); });
+    }
+
+    function setGutterSize (gutterElement, gutSize) {
+        var style = gutterStyle(dimension, gutSize);
+
+        // eslint-disable-next-line no-param-reassign
+        Object.keys(style).forEach(function (prop) { return (gutterElement.style[prop] = style[prop]); });
+    }
+
+    // Actually adjust the size of elements `a` and `b` to `offset` while dragging.
+    // calc is used to allow calc(percentage + gutterpx) on the whole split instance,
+    // which allows the viewport to be resized without additional logic.
+    // Element a's size is the same as offset. b's size is total size - a size.
+    // Both sizes are calculated from the initial parent percentage,
+    // then the gutter size is subtracted.
+    function adjust (offset) {
+        var a = elements[this.a];
+        var b = elements[this.b];
+        var percentage = a.size + b.size;
+
+        a.size = (offset / this.size) * percentage;
+        b.size = (percentage - ((offset / this.size) * percentage));
+
+        setElementSize(a.element, a.size, this.aGutterSize);
+        setElementSize(b.element, b.size, this.bGutterSize);
+    }
+
+    // drag, where all the magic happens. The logic is really quite simple:
+    //
+    // 1. Ignore if the pair is not dragging.
+    // 2. Get the offset of the event.
+    // 3. Snap offset to min if within snappable range (within min + snapOffset).
+    // 4. Actually adjust each element in the pair to offset.
+    //
+    // ---------------------------------------------------------------------
+    // |    | <- a.minSize               ||              b.minSize -> |    |
+    // |    |  | <- this.snapOffset      ||     this.snapOffset -> |  |    |
+    // |    |  |                         ||                        |  |    |
+    // |    |  |                         ||                        |  |    |
+    // ---------------------------------------------------------------------
+    // | <- this.start                                        this.size -> |
+    function drag (e) {
+        var offset;
+
+        if (!this.dragging) { return }
+
+        // Get the offset of the event from the first side of the
+        // pair `this.start`. Supports touch events, but not multitouch, so only the first
+        // finger `touches[0]` is counted.
+        if ('touches' in e) {
+            offset = e.touches[0][clientAxis] - this.start;
+        } else {
+            offset = e[clientAxis] - this.start;
+        }
+
+        // If within snapOffset of min or max, set offset to min or max.
+        // snapOffset buffers a.minSize and b.minSize, so logic is opposite for both.
+        // Include the appropriate gutter sizes to prevent overflows.
+        if (offset <= elements[this.a].minSize + snapOffset + this.aGutterSize) {
+            offset = elements[this.a].minSize + this.aGutterSize;
+        } else if (offset >= this.size - (elements[this.b].minSize + snapOffset + this.bGutterSize)) {
+            offset = this.size - (elements[this.b].minSize + this.bGutterSize);
+        }
+
+        // Actually adjust the size.
+        adjust.call(this, offset);
+
+        // Call the drag callback continously. Don't do anything too intensive
+        // in this callback.
+        if (options.onDrag) {
+            options.onDrag();
+        }
+    }
+
+    // Cache some important sizes when drag starts, so we don't have to do that
+    // continously:
+    //
+    // `size`: The total size of the pair. First + second + first gutter + second gutter.
+    // `start`: The leading side of the first element.
+    //
+    // ------------------------------------------------
+    // |      aGutterSize -> |||                      |
+    // |                     |||                      |
+    // |                     |||                      |
+    // |                     ||| <- bGutterSize       |
+    // ------------------------------------------------
+    // | <- start                             size -> |
+    function calculateSizes () {
+        // Figure out the parent size minus padding.
+        var a = elements[this.a].element;
+        var b = elements[this.b].element;
+
+        this.size = a[getBoundingClientRect]()[dimension] + b[getBoundingClientRect]()[dimension] + this.aGutterSize + this.bGutterSize;
+        this.start = a[getBoundingClientRect]()[position];
+    }
+
+    // stopDragging is very similar to startDragging in reverse.
+    function stopDragging () {
+        var self = this;
+        var a = elements[self.a].element;
+        var b = elements[self.b].element;
+
+        if (self.dragging && options.onDragEnd) {
+            options.onDragEnd();
+        }
+
+        self.dragging = false;
+
+        // Remove the stored event listeners. This is why we store them.
+        global[removeEventListener]('mouseup', self.stop);
+        global[removeEventListener]('touchend', self.stop);
+        global[removeEventListener]('touchcancel', self.stop);
+
+        self.parent[removeEventListener]('mousemove', self.move);
+        self.parent[removeEventListener]('touchmove', self.move);
+
+        // Delete them once they are removed. I think this makes a difference
+        // in memory usage with a lot of splits on one page. But I don't know for sure.
+        delete self.stop;
+        delete self.move;
+
+        a[removeEventListener]('selectstart', NOOP);
+        a[removeEventListener]('dragstart', NOOP);
+        b[removeEventListener]('selectstart', NOOP);
+        b[removeEventListener]('dragstart', NOOP);
+
+        a.style.userSelect = '';
+        a.style.webkitUserSelect = '';
+        a.style.MozUserSelect = '';
+        a.style.pointerEvents = '';
+
+        b.style.userSelect = '';
+        b.style.webkitUserSelect = '';
+        b.style.MozUserSelect = '';
+        b.style.pointerEvents = '';
+
+        self.gutter.style.cursor = '';
+        self.parent.style.cursor = '';
+    }
+
+    // startDragging calls `calculateSizes` to store the inital size in the pair object.
+    // It also adds event listeners for mouse/touch events,
+    // and prevents selection while dragging so avoid the selecting text.
+    function startDragging (e) {
+        // Alias frequently used variables to save space. 200 bytes.
+        var self = this;
+        var a = elements[self.a].element;
+        var b = elements[self.b].element;
+
+        // Call the onDragStart callback.
+        if (!self.dragging && options.onDragStart) {
+            options.onDragStart();
+        }
+
+        // Don't actually drag the element. We emulate that in the drag function.
+        e.preventDefault();
+
+        // Set the dragging property of the pair object.
+        self.dragging = true;
+
+        // Create two event listeners bound to the same pair object and store
+        // them in the pair object.
+        self.move = drag.bind(self);
+        self.stop = stopDragging.bind(self);
+
+        // All the binding. `window` gets the stop events in case we drag out of the elements.
+        global[addEventListener]('mouseup', self.stop);
+        global[addEventListener]('touchend', self.stop);
+        global[addEventListener]('touchcancel', self.stop);
+
+        self.parent[addEventListener]('mousemove', self.move);
+        self.parent[addEventListener]('touchmove', self.move);
+
+        // Disable selection. Disable!
+        a[addEventListener]('selectstart', NOOP);
+        a[addEventListener]('dragstart', NOOP);
+        b[addEventListener]('selectstart', NOOP);
+        b[addEventListener]('dragstart', NOOP);
+
+        a.style.userSelect = 'none';
+        a.style.webkitUserSelect = 'none';
+        a.style.MozUserSelect = 'none';
+        a.style.pointerEvents = 'none';
+
+        b.style.userSelect = 'none';
+        b.style.webkitUserSelect = 'none';
+        b.style.MozUserSelect = 'none';
+        b.style.pointerEvents = 'none';
+
+        // Set the cursor, both on the gutter and the parent element.
+        // Doing only a, b and gutter causes flickering.
+        self.gutter.style.cursor = cursor;
+        self.parent.style.cursor = cursor;
+
+        // Cache the initial sizes of the pair.
+        calculateSizes.call(self);
+    }
+
+    // 5. Create pair and element objects. Each pair has an index reference to
+    // elements `a` and `b` of the pair (first and second elements).
+    // Loop through the elements while pairing them off. Every pair gets a
+    // `pair` object, a gutter, and isFirst/isLast properties.
+    //
+    // Basic logic:
+    //
+    // - Starting with the second element `i > 0`, create `pair` objects with
+    //   `a = i - 1` and `b = i`
+    // - Set gutter sizes based on the _pair_ being first/last. The first and last
+    //   pair have gutterSize / 2, since they only have one half gutter, and not two.
+    // - Create gutter elements and add event listeners.
+    // - Set the size of the elements, minus the gutter sizes.
+    //
+    // -----------------------------------------------------------------------
+    // |     i=0     |         i=1         |        i=2       |      i=3     |
+    // |             |       isFirst       |                  |     isLast   |
+    // |           pair 0                pair 1             pair 2           |
+    // |             |                     |                  |              |
+    // -----------------------------------------------------------------------
+    var pairs = [];
+    elements = ids.map(function (id, i) {
+        // Create the element object.
+        var element = {
+            element: elementOrSelector(id),
+            size: sizes[i],
+            minSize: minSizes[i],
+        };
+
+        var pair;
+
+        if (i > 0) {
+            // Create the pair object with it's metadata.
+            pair = {
+                a: i - 1,
+                b: i,
+                dragging: false,
+                isFirst: (i === 1),
+                isLast: (i === ids.length - 1),
+                direction: direction,
+                parent: parent,
+            };
+
+            // For first and last pairs, first and last gutter width is half.
+            pair.aGutterSize = gutterSize;
+            pair.bGutterSize = gutterSize;
+
+            if (pair.isFirst) {
+                pair.aGutterSize = gutterSize / 2;
+            }
+
+            if (pair.isLast) {
+                pair.bGutterSize = gutterSize / 2;
+            }
+
+            // if the parent has a reverse flex-direction, switch the pair elements.
+            if (parentFlexDirection === 'row-reverse' || parentFlexDirection === 'column-reverse') {
+                var temp = pair.a;
+                pair.a = pair.b;
+                pair.b = temp;
+            }
+        }
+
+        // Determine the size of the current element. IE8 is supported by
+        // staticly assigning sizes without draggable gutters. Assigns a string
+        // to `size`.
+        //
+        // IE9 and above
+        if (!isIE8) {
+            // Create gutter elements for each pair.
+            if (i > 0) {
+                var gutterElement = gutter(i, direction);
+                setGutterSize(gutterElement, gutterSize);
+
+                gutterElement[addEventListener]('mousedown', startDragging.bind(pair));
+                gutterElement[addEventListener]('touchstart', startDragging.bind(pair));
+
+                parent.insertBefore(gutterElement, element.element);
+
+                pair.gutter = gutterElement;
+            }
+        }
+
+        // Set the element size to our determined size.
+        // Half-size gutters for first and last elements.
+        if (i === 0 || i === ids.length - 1) {
+            setElementSize(element.element, element.size, gutterSize / 2);
+        } else {
+            setElementSize(element.element, element.size, gutterSize);
+        }
+
+        var computedSize = element.element[getBoundingClientRect]()[dimension];
+
+        if (computedSize < element.minSize) {
+            element.minSize = computedSize;
+        }
+
+        // After the first iteration, and we have a pair object, append it to the
+        // list of pairs.
+        if (i > 0) {
+            pairs.push(pair);
+        }
+
+        return element
+    });
+
+    function setSizes (newSizes) {
+        newSizes.forEach(function (newSize, i) {
+            if (i > 0) {
+                var pair = pairs[i - 1];
+                var a = elements[pair.a];
+                var b = elements[pair.b];
+
+                a.size = newSizes[i - 1];
+                b.size = newSize;
+
+                setElementSize(a.element, a.size, pair.aGutterSize);
+                setElementSize(b.element, b.size, pair.bGutterSize);
+            }
+        });
+    }
+
+    function destroy () {
+        pairs.forEach(function (pair) {
+            pair.parent.removeChild(pair.gutter);
+            elements[pair.a].element.style[dimension] = '';
+            elements[pair.b].element.style[dimension] = '';
+        });
+    }
+
+    if (isIE8) {
+        return {
+            setSizes: setSizes,
+            destroy: destroy,
+        }
+    }
+
+    return {
+        setSizes: setSizes,
+        getSizes: function getSizes () {
+            return elements.map(function (element) { return element.size; })
+        },
+        collapse: function collapse (i) {
+            if (i === pairs.length) {
+                var pair = pairs[i - 1];
+
+                calculateSizes.call(pair);
+
+                if (!isIE8) {
+                    adjust.call(pair, pair.size - pair.bGutterSize);
+                }
+            } else {
+                var pair$1 = pairs[i];
+
+                calculateSizes.call(pair$1);
+
+                if (!isIE8) {
+                    adjust.call(pair$1, pair$1.aGutterSize);
+                }
+            }
+        },
+        destroy: destroy,
+    }
+};
+
+return Split;
+
+})));

--- a/index.html
+++ b/index.html
@@ -52,11 +52,11 @@
     <script src="assets/js/export-to-dejacode.js"></script>
     <script src="assets/js/nodeview.js"></script>
     <script src="assets/js/select2.js"></script>
-    <script src='node_modules/split.js/split.js'></script>
+    <script src='assets/js/split.js'></script>
 </head>
 <body>
 <div class="row root-div" id="root-div">
-    <div class="split split-horizontal col-md-1" id="sidebar-div">
+        <div class="split split-horizontal col-md-1" id="sidebar-div">
         <!-- Sidebar -->
         <div id="sidebar-wrapper">
             <ul class="sidebar-nav">
@@ -87,10 +87,10 @@
          <div id="jstree"></div>
     </div>
 
-    <div id="tabbar" class="split split-horizontal col-md-9">
+     <div id="tabbar" class="split split-horizontal col-md-9">
         <table id="clues-table" class="display table table-striped table-bordered dataTable no-footer"  cellspacing="0" width="100%" >
         </table>
-        <div id="component-container" class="node-hide">
+         <div id="component-container" class="node-hide">
             <p class="lead">Component Summary</p>
             <table id="components-table" class="display table table-striped table-bordered dataTable no-footer"  cellspacing="0" width="100%" >
             </table>

--- a/index.html
+++ b/index.html
@@ -52,10 +52,11 @@
     <script src="assets/js/export-to-dejacode.js"></script>
     <script src="assets/js/nodeview.js"></script>
     <script src="assets/js/select2.js"></script>
+    <script src='node_modules/split.js/split.js'></script>
 </head>
 <body>
-<div class="row">
-    <div class="col-md-1">
+<div class="row root-div" id="root-div">
+    <div class="split split-horizontal col-md-1" id="sidebar-div">
         <!-- Sidebar -->
         <div id="sidebar-wrapper">
             <ul class="sidebar-nav">
@@ -82,11 +83,11 @@
     </div>
     <div id="indicator-text"><h4>Creating Database ...</h4></div>
     <div id="db-indicator"></div>
-    <div class="col-md-2" id="leftCol">
-        <div id="jstree"></div>
+    <div class="split split-horizontal col-md-2" id="leftCol">
+         <div id="jstree"></div>
     </div>
 
-    <div id="tabbar" class="col-md-9">
+    <div id="tabbar" class="split split-horizontal col-md-9">
         <table id="clues-table" class="display table table-striped table-bordered dataTable no-footer"  cellspacing="0" width="100%" >
         </table>
         <div id="component-container" class="node-hide">

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8440,11 +8440,6 @@
       "from": "speedometer@>=0.1.2 <0.2.0",
       "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-0.1.4.tgz"
     },
-    "split.js": {
-      "version": "1.3.5",
-      "from": "split.js@latest",
-      "resolved": "https://registry.npmjs.org/split.js/-/split.js-1.3.5.tgz"
-    },
     "sqlite3": {
       "version": "3.1.8",
       "from": "sqlite3@latest",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5,92 +5,78 @@
     "ajv": {
       "version": "4.11.8",
       "from": "ajv@>=4.9.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz"
     },
     "array-find-index": {
       "version": "1.0.2",
       "from": "array-find-index@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz"
     },
     "asar": {
       "version": "0.11.0",
       "from": "https://registry.npmjs.org/asar/-/asar-0.11.0.tgz",
       "resolved": "https://registry.npmjs.org/asar/-/asar-0.11.0.tgz",
-      "dev": true,
       "dependencies": {
         "chromium-pickle-js": {
           "version": "0.1.0",
           "from": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.1.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.1.0.tgz"
         },
         "commander": {
           "version": "2.9.0",
           "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "dev": true,
           "dependencies": {
             "graceful-readlink": {
               "version": "1.0.1",
               "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
             }
           }
         },
         "cuint": {
           "version": "0.2.1",
           "from": "https://registry.npmjs.org/cuint/-/cuint-0.2.1.tgz",
-          "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.1.tgz"
         },
         "glob": {
           "version": "6.0.4",
           "from": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-          "dev": true,
           "dependencies": {
             "inflight": {
               "version": "1.0.5",
               "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-              "dev": true,
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.2",
                   "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                 }
               }
             },
             "inherits": {
               "version": "2.0.1",
               "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "once": {
               "version": "1.3.3",
               "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-              "dev": true,
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.2",
                   "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                 }
               }
             },
             "path-is-absolute": {
               "version": "1.0.0",
               "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             }
           }
         },
@@ -98,25 +84,21 @@
           "version": "3.0.0",
           "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-          "dev": true,
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.5",
               "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz",
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz",
-              "dev": true,
               "dependencies": {
                 "balanced-match": {
                   "version": "0.4.1",
                   "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz"
                 },
                 "concat-map": {
                   "version": "0.0.1",
                   "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                 }
               }
             }
@@ -126,13 +108,11 @@
           "version": "0.5.1",
           "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "dev": true,
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
               "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
@@ -140,37 +120,31 @@
           "version": "0.3.0",
           "from": "https://registry.npmjs.org/mksnapshot/-/mksnapshot-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/mksnapshot/-/mksnapshot-0.3.0.tgz",
-          "dev": true,
           "dependencies": {
             "decompress-zip": {
               "version": "0.3.0",
               "from": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.0.tgz",
-              "dev": true,
               "dependencies": {
                 "binary": {
                   "version": "0.3.0",
                   "from": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "buffers": {
                       "version": "0.1.1",
                       "from": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
                     },
                     "chainsaw": {
                       "version": "0.1.0",
                       "from": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-                      "dev": true,
                       "dependencies": {
                         "traverse": {
                           "version": "0.3.9",
                           "from": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-                          "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
                         }
                       }
                     }
@@ -179,64 +153,54 @@
                 "graceful-fs": {
                   "version": "4.1.4",
                   "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
                 },
                 "mkpath": {
                   "version": "0.1.0",
                   "from": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz"
                 },
                 "nopt": {
                   "version": "3.0.6",
                   "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-                  "dev": true,
                   "dependencies": {
                     "abbrev": {
                       "version": "1.0.9",
                       "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
                     }
                   }
                 },
                 "q": {
                   "version": "1.4.1",
                   "from": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
                 },
                 "readable-stream": {
                   "version": "1.1.14",
                   "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-                  "dev": true,
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
                       "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
                       "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
                       "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
                       "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     }
                   }
                 },
@@ -244,19 +208,16 @@
                   "version": "0.0.3",
                   "from": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
-                  "dev": true,
                   "dependencies": {
                     "nopt": {
                       "version": "1.0.10",
                       "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
                       "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-                      "dev": true,
                       "dependencies": {
                         "abbrev": {
                           "version": "1.0.9",
                           "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-                          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
                         }
                       }
                     }
@@ -268,81 +229,68 @@
               "version": "0.26.7",
               "from": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
               "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
-              "dev": true,
               "dependencies": {
                 "graceful-fs": {
                   "version": "4.1.4",
                   "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
                 },
                 "jsonfile": {
                   "version": "2.3.1",
                   "from": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.3.1.tgz",
-                  "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.3.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.3.1.tgz"
                 },
                 "klaw": {
                   "version": "1.3.0",
                   "from": "https://registry.npmjs.org/klaw/-/klaw-1.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.0.tgz"
                 },
                 "path-is-absolute": {
                   "version": "1.0.0",
                   "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                 },
                 "rimraf": {
                   "version": "2.5.2",
                   "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
                   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
-                  "dev": true,
                   "dependencies": {
                     "glob": {
                       "version": "7.0.4",
                       "from": "https://registry.npmjs.org/glob/-/glob-7.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.4.tgz",
-                      "dev": true,
                       "dependencies": {
                         "fs.realpath": {
                           "version": "1.0.0",
                           "from": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
                         },
                         "inflight": {
                           "version": "1.0.5",
                           "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
                           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-                          "dev": true,
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.2",
                               "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                             }
                           }
                         },
                         "inherits": {
                           "version": "2.0.1",
                           "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "once": {
                           "version": "1.3.3",
                           "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                          "dev": true,
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.2",
                               "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                             }
                           }
                         }
@@ -356,49 +304,41 @@
               "version": "2.55.0",
               "from": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
               "resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
-              "dev": true,
               "dependencies": {
                 "aws-sign2": {
                   "version": "0.5.0",
                   "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                 },
                 "bl": {
                   "version": "0.9.5",
                   "from": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
-                  "dev": true,
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.34",
                       "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                      "dev": true,
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
                           "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
                           "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
                           "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
                           "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         }
                       }
                     }
@@ -407,40 +347,34 @@
                 "caseless": {
                   "version": "0.9.0",
                   "from": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
-                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
                 },
                 "combined-stream": {
                   "version": "0.0.7",
                   "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-                  "dev": true,
                   "dependencies": {
                     "delayed-stream": {
                       "version": "0.0.5",
                       "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                     }
                   }
                 },
                 "forever-agent": {
                   "version": "0.6.1",
                   "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                 },
                 "form-data": {
                   "version": "0.2.0",
                   "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "async": {
                       "version": "0.9.2",
                       "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                     }
                   }
                 },
@@ -448,43 +382,36 @@
                   "version": "1.8.0",
                   "from": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
                   "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "bluebird": {
                       "version": "2.10.2",
                       "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
-                      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
                     },
                     "chalk": {
                       "version": "1.1.3",
                       "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                      "dev": true,
                       "dependencies": {
                         "ansi-styles": {
                           "version": "2.2.1",
                           "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                         },
                         "escape-string-regexp": {
                           "version": "1.0.5",
                           "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                         },
                         "has-ansi": {
                           "version": "2.0.0",
                           "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                          "dev": true,
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
                               "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                             }
                           }
                         },
@@ -492,21 +419,18 @@
                           "version": "3.0.1",
                           "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                          "dev": true,
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
                               "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                             }
                           }
                         },
                         "supports-color": {
                           "version": "2.0.0",
                           "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                         }
                       }
                     },
@@ -514,39 +438,33 @@
                       "version": "2.13.1",
                       "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
                       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
-                      "dev": true,
                       "dependencies": {
                         "generate-function": {
                           "version": "2.0.0",
                           "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                         },
                         "generate-object-property": {
                           "version": "1.2.0",
                           "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                          "dev": true,
                           "dependencies": {
                             "is-property": {
                               "version": "1.0.2",
                               "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                             }
                           }
                         },
                         "jsonpointer": {
                           "version": "2.0.0",
                           "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                         },
                         "xtend": {
                           "version": "4.0.1",
                           "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                         }
                       }
                     }
@@ -556,31 +474,26 @@
                   "version": "2.3.1",
                   "from": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-                  "dev": true,
                   "dependencies": {
                     "boom": {
                       "version": "2.10.1",
                       "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
                     },
                     "cryptiles": {
                       "version": "2.0.5",
                       "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                     },
                     "hoek": {
                       "version": "2.16.3",
                       "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                     },
                     "sntp": {
                       "version": "1.0.9",
                       "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                     }
                   }
                 },
@@ -588,89 +501,75 @@
                   "version": "0.10.1",
                   "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-                  "dev": true,
                   "dependencies": {
                     "asn1": {
                       "version": "0.1.11",
                       "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                     },
                     "assert-plus": {
                       "version": "0.1.5",
                       "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                     },
                     "ctype": {
                       "version": "0.5.3",
                       "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                     }
                   }
                 },
                 "isstream": {
                   "version": "0.1.2",
                   "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
                   "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                 },
                 "mime-types": {
                   "version": "2.0.14",
                   "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-                  "dev": true,
                   "dependencies": {
                     "mime-db": {
                       "version": "1.12.0",
                       "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                     }
                   }
                 },
                 "node-uuid": {
                   "version": "1.4.7",
                   "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
                 },
                 "oauth-sign": {
                   "version": "0.6.0",
                   "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
                 },
                 "qs": {
                   "version": "2.4.2",
                   "from": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.5",
                   "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
                 },
                 "tough-cookie": {
                   "version": "2.2.2",
                   "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.3",
                   "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
                 }
               }
             }
@@ -681,330 +580,276 @@
     "asn1": {
       "version": "0.2.3",
       "from": "asn1@>=0.2.3 <0.3.0",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
     },
     "assert-plus": {
       "version": "0.2.0",
       "from": "assert-plus@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
     },
     "asynckit": {
       "version": "0.4.0",
       "from": "asynckit@>=0.4.0 <0.5.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
     },
     "aws-sign2": {
       "version": "0.6.0",
       "from": "aws-sign2@>=0.6.0 <0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
     },
     "aws4": {
       "version": "1.6.0",
       "from": "aws4@>=1.2.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
     },
     "balanced-match": {
       "version": "1.0.0",
       "from": "balanced-match@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
       "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "dev": true,
-      "optional": true
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz"
     },
     "boom": {
       "version": "2.10.1",
       "from": "boom@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
     },
     "brace-expansion": {
       "version": "1.1.8",
       "from": "brace-expansion@>=1.1.7 <2.0.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
     },
     "builtin-modules": {
       "version": "1.1.1",
       "from": "builtin-modules@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
     },
     "camelcase": {
       "version": "2.1.1",
       "from": "camelcase@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
     },
     "camelcase-keys": {
       "version": "2.1.0",
       "from": "camelcase-keys@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz"
     },
     "caseless": {
       "version": "0.12.0",
       "from": "caseless@>=0.12.0 <0.13.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
     },
     "chai": {
       "version": "3.5.0",
       "from": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
       "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
-      "dev": true,
       "dependencies": {
         "assertion-error": {
           "version": "1.0.2",
           "from": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz"
         },
         "deep-eql": {
           "version": "0.1.3",
           "from": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
           "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-          "dev": true,
           "dependencies": {
             "type-detect": {
               "version": "0.1.1",
               "from": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
             }
           }
         },
         "type-detect": {
           "version": "1.0.0",
           "from": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
         }
       }
     },
     "chai-subset": {
       "version": "1.5.0",
       "from": "chai-subset@latest",
-      "resolved": "https://registry.npmjs.org/chai-subset/-/chai-subset-1.5.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/chai-subset/-/chai-subset-1.5.0.tgz"
     },
     "co": {
       "version": "4.6.0",
       "from": "co@>=4.6.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
     },
     "combined-stream": {
       "version": "1.0.5",
       "from": "combined-stream@>=1.0.5 <1.1.0",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
     },
     "concat-map": {
       "version": "0.0.1",
       "from": "concat-map@0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
     },
     "concat-stream": {
       "version": "1.6.0",
       "from": "concat-stream@1.6.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "dev": true,
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
           "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
           "version": "2.2.11",
           "from": "readable-stream@>=2.2.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz"
         },
         "safe-buffer": {
           "version": "5.0.1",
           "from": "safe-buffer@>=5.0.1 <5.1.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
         },
         "string_decoder": {
           "version": "1.0.2",
           "from": "string_decoder@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz"
         }
       }
     },
     "core-util-is": {
       "version": "1.0.2",
       "from": "core-util-is@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
     },
     "cryptiles": {
       "version": "2.0.5",
       "from": "cryptiles@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
     },
     "currently-unhandled": {
       "version": "0.4.1",
       "from": "currently-unhandled@>=0.4.1 <0.5.0",
-      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz"
     },
     "dashdash": {
       "version": "1.14.1",
       "from": "dashdash@>=1.12.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "dev": true,
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
           "from": "assert-plus@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
     },
     "debug": {
       "version": "2.6.8",
       "from": "debug@>=2.2.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz"
     },
     "decamelize": {
       "version": "1.2.0",
       "from": "decamelize@>=1.1.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
     },
     "deep-extend": {
       "version": "0.4.2",
       "from": "deep-extend@>=0.4.0 <0.5.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz"
     },
     "delayed-stream": {
       "version": "1.0.0",
       "from": "delayed-stream@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
     },
     "ecc-jsbn": {
       "version": "0.1.1",
       "from": "ecc-jsbn@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "dev": true,
-      "optional": true
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
     },
     "electron": {
       "version": "1.4.0",
       "from": "electron@1.4.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-1.4.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/electron/-/electron-1.4.0.tgz"
     },
     "electron-download": {
       "version": "2.2.1",
       "from": "electron-download@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/electron-download/-/electron-download-2.2.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/electron-download/-/electron-download-2.2.1.tgz"
     },
     "electron-packager": {
       "version": "7.7.0",
       "from": "https://registry.npmjs.org/electron-packager/-/electron-packager-7.7.0.tgz",
       "resolved": "https://registry.npmjs.org/electron-packager/-/electron-packager-7.7.0.tgz",
-      "dev": true,
       "dependencies": {
         "asar": {
           "version": "0.12.3",
           "from": "https://registry.npmjs.org/asar/-/asar-0.12.3.tgz",
           "resolved": "https://registry.npmjs.org/asar/-/asar-0.12.3.tgz",
-          "dev": true,
           "dependencies": {
             "chromium-pickle-js": {
               "version": "0.2.0",
               "from": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz"
             },
             "commander": {
               "version": "2.9.0",
               "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-              "dev": true,
               "dependencies": {
                 "graceful-readlink": {
                   "version": "1.0.1",
                   "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                 }
               }
             },
             "cuint": {
               "version": "0.2.2",
               "from": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
-              "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz"
             },
             "glob": {
               "version": "6.0.4",
               "from": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
               "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-              "dev": true,
               "dependencies": {
                 "inflight": {
                   "version": "1.0.5",
                   "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-                  "dev": true,
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.2",
                       "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.3",
                   "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "once": {
                   "version": "1.4.0",
                   "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.2",
                       "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 },
                 "path-is-absolute": {
                   "version": "1.0.0",
                   "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                 }
               }
             },
@@ -1012,25 +857,21 @@
               "version": "3.0.3",
               "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-              "dev": true,
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.6",
                   "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                  "dev": true,
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.4.2",
                       "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
                       "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
                 }
@@ -1040,13 +881,11 @@
               "version": "0.5.1",
               "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "dev": true,
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
                   "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
@@ -1054,37 +893,31 @@
               "version": "0.3.0",
               "from": "https://registry.npmjs.org/mksnapshot/-/mksnapshot-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/mksnapshot/-/mksnapshot-0.3.0.tgz",
-              "dev": true,
               "dependencies": {
                 "decompress-zip": {
                   "version": "0.3.0",
                   "from": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "binary": {
                       "version": "0.3.0",
                       "from": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-                      "dev": true,
                       "dependencies": {
                         "buffers": {
                           "version": "0.1.1",
                           "from": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-                          "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
                         },
                         "chainsaw": {
                           "version": "0.1.0",
                           "from": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-                          "dev": true,
                           "dependencies": {
                             "traverse": {
                               "version": "0.3.9",
                               "from": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-                              "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
                             }
                           }
                         }
@@ -1093,64 +926,54 @@
                     "graceful-fs": {
                       "version": "4.1.8",
                       "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.8.tgz",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.8.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.8.tgz"
                     },
                     "mkpath": {
                       "version": "0.1.0",
                       "from": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz"
                     },
                     "nopt": {
                       "version": "3.0.6",
                       "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-                      "dev": true,
                       "dependencies": {
                         "abbrev": {
                           "version": "1.0.9",
                           "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-                          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
                         }
                       }
                     },
                     "q": {
                       "version": "1.4.1",
                       "from": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
                     },
                     "readable-stream": {
                       "version": "1.1.14",
                       "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-                      "dev": true,
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
                           "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "inherits": {
                           "version": "2.0.3",
                           "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
                           "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
                           "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         }
                       }
                     },
@@ -1158,19 +981,16 @@
                       "version": "0.0.3",
                       "from": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
-                      "dev": true,
                       "dependencies": {
                         "nopt": {
                           "version": "1.0.10",
                           "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
                           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-                          "dev": true,
                           "dependencies": {
                             "abbrev": {
                               "version": "1.0.9",
                               "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-                              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
                             }
                           }
                         }
@@ -1182,81 +1002,68 @@
                   "version": "0.26.7",
                   "from": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
                   "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
-                  "dev": true,
                   "dependencies": {
                     "graceful-fs": {
                       "version": "4.1.8",
                       "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.8.tgz",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.8.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.8.tgz"
                     },
                     "jsonfile": {
                       "version": "2.4.0",
                       "from": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-                      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz"
                     },
                     "klaw": {
                       "version": "1.3.0",
                       "from": "https://registry.npmjs.org/klaw/-/klaw-1.3.0.tgz",
-                      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.0.tgz"
                     },
                     "path-is-absolute": {
                       "version": "1.0.0",
                       "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                     },
                     "rimraf": {
                       "version": "2.5.4",
                       "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
                       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-                      "dev": true,
                       "dependencies": {
                         "glob": {
                           "version": "7.1.0",
                           "from": "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz",
-                          "dev": true,
                           "dependencies": {
                             "fs.realpath": {
                               "version": "1.0.0",
                               "from": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
                             },
                             "inflight": {
                               "version": "1.0.5",
                               "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
                               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-                              "dev": true,
                               "dependencies": {
                                 "wrappy": {
                                   "version": "1.0.2",
                                   "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                                 }
                               }
                             },
                             "inherits": {
                               "version": "2.0.3",
                               "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                             },
                             "once": {
                               "version": "1.4.0",
                               "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                               "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                              "dev": true,
                               "dependencies": {
                                 "wrappy": {
                                   "version": "1.0.2",
                                   "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                                 }
                               }
                             }
@@ -1270,49 +1077,41 @@
                   "version": "2.55.0",
                   "from": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
                   "resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "aws-sign2": {
                       "version": "0.5.0",
                       "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                     },
                     "bl": {
                       "version": "0.9.5",
                       "from": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
                       "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
-                      "dev": true,
                       "dependencies": {
                         "readable-stream": {
                           "version": "1.0.34",
                           "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                          "dev": true,
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.2",
                               "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                             },
                             "inherits": {
                               "version": "2.0.3",
                               "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                             },
                             "isarray": {
                               "version": "0.0.1",
                               "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                             },
                             "string_decoder": {
                               "version": "0.10.31",
                               "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             }
                           }
                         }
@@ -1321,40 +1120,34 @@
                     "caseless": {
                       "version": "0.9.0",
                       "from": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
-                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
                     },
                     "combined-stream": {
                       "version": "0.0.7",
                       "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-                      "dev": true,
                       "dependencies": {
                         "delayed-stream": {
                           "version": "0.0.5",
                           "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                         }
                       }
                     },
                     "forever-agent": {
                       "version": "0.6.1",
                       "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                     },
                     "form-data": {
                       "version": "0.2.0",
                       "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-                      "dev": true,
                       "dependencies": {
                         "async": {
                           "version": "0.9.2",
                           "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-                          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                         }
                       }
                     },
@@ -1362,43 +1155,36 @@
                       "version": "1.8.0",
                       "from": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
                       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
-                      "dev": true,
                       "dependencies": {
                         "bluebird": {
                           "version": "2.11.0",
                           "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-                          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz"
                         },
                         "chalk": {
                           "version": "1.1.3",
                           "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                          "dev": true,
                           "dependencies": {
                             "ansi-styles": {
                               "version": "2.2.1",
                               "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                             },
                             "escape-string-regexp": {
                               "version": "1.0.5",
                               "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                             },
                             "has-ansi": {
                               "version": "2.0.0",
                               "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "dev": true,
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
                                   "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
@@ -1406,21 +1192,18 @@
                               "version": "3.0.1",
                               "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                              "dev": true,
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
                                   "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "supports-color": {
                               "version": "2.0.0",
                               "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                             }
                           }
                         },
@@ -1428,39 +1211,33 @@
                           "version": "2.14.0",
                           "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.14.0.tgz",
                           "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.14.0.tgz",
-                          "dev": true,
                           "dependencies": {
                             "generate-function": {
                               "version": "2.0.0",
                               "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                             },
                             "generate-object-property": {
                               "version": "1.2.0",
                               "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                               "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                              "dev": true,
                               "dependencies": {
                                 "is-property": {
                                   "version": "1.0.2",
                                   "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                                 }
                               }
                             },
                             "jsonpointer": {
                               "version": "2.0.0",
                               "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                             },
                             "xtend": {
                               "version": "4.0.1",
                               "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                             }
                           }
                         }
@@ -1470,31 +1247,26 @@
                       "version": "2.3.1",
                       "from": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
                       "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-                      "dev": true,
                       "dependencies": {
                         "boom": {
                           "version": "2.10.1",
                           "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
                         },
                         "cryptiles": {
                           "version": "2.0.5",
                           "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                         },
                         "hoek": {
                           "version": "2.16.3",
                           "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                         },
                         "sntp": {
                           "version": "1.0.9",
                           "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                         }
                       }
                     },
@@ -1502,89 +1274,75 @@
                       "version": "0.10.1",
                       "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-                      "dev": true,
                       "dependencies": {
                         "asn1": {
                           "version": "0.1.11",
                           "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                         },
                         "assert-plus": {
                           "version": "0.1.5",
                           "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                         },
                         "ctype": {
                           "version": "0.5.3",
                           "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-                          "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                         }
                       }
                     },
                     "isstream": {
                       "version": "0.1.2",
                       "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                     },
                     "json-stringify-safe": {
                       "version": "5.0.1",
                       "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                     },
                     "mime-types": {
                       "version": "2.0.14",
                       "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-                      "dev": true,
                       "dependencies": {
                         "mime-db": {
                           "version": "1.12.0",
                           "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                         }
                       }
                     },
                     "node-uuid": {
                       "version": "1.4.7",
                       "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
                     },
                     "oauth-sign": {
                       "version": "0.6.0",
                       "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
-                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
                     },
                     "qs": {
                       "version": "2.4.2",
                       "from": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
-                      "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz"
                     },
                     "stringstream": {
                       "version": "0.0.5",
                       "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
                     },
                     "tough-cookie": {
                       "version": "2.3.1",
                       "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
-                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz"
                     },
                     "tunnel-agent": {
                       "version": "0.4.3",
                       "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
                     }
                   }
                 }
@@ -1594,13 +1352,11 @@
               "version": "0.0.28",
               "from": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
               "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
-              "dev": true,
               "dependencies": {
                 "os-tmpdir": {
                   "version": "1.0.1",
                   "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                 }
               }
             }
@@ -1610,13 +1366,11 @@
           "version": "2.2.0",
           "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "dev": true,
           "dependencies": {
             "ms": {
               "version": "0.7.1",
               "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
@@ -1624,25 +1378,21 @@
           "version": "2.2.1",
           "from": "https://registry.npmjs.org/electron-download/-/electron-download-2.2.1.tgz",
           "resolved": "https://registry.npmjs.org/electron-download/-/electron-download-2.2.1.tgz",
-          "dev": true,
           "dependencies": {
             "home-path": {
               "version": "1.0.3",
               "from": "https://registry.npmjs.org/home-path/-/home-path-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/home-path/-/home-path-1.0.3.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/home-path/-/home-path-1.0.3.tgz"
             },
             "mkdirp": {
               "version": "0.5.1",
               "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "dev": true,
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
                   "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
@@ -1650,69 +1400,58 @@
               "version": "2.1.1",
               "from": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
               "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
-              "dev": true,
               "dependencies": {
                 "ncp": {
                   "version": "2.0.0",
                   "from": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz"
                 },
                 "rimraf": {
                   "version": "2.4.5",
                   "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
                   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
-                  "dev": true,
                   "dependencies": {
                     "glob": {
                       "version": "6.0.4",
                       "from": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-                      "dev": true,
                       "dependencies": {
                         "inflight": {
                           "version": "1.0.5",
                           "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
                           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-                          "dev": true,
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.2",
                               "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                             }
                           }
                         },
                         "inherits": {
                           "version": "2.0.3",
                           "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                         },
                         "minimatch": {
                           "version": "3.0.3",
                           "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                          "dev": true,
                           "dependencies": {
                             "brace-expansion": {
                               "version": "1.1.6",
                               "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                              "dev": true,
                               "dependencies": {
                                 "balanced-match": {
                                   "version": "0.4.2",
                                   "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                                 },
                                 "concat-map": {
                                   "version": "0.0.1",
                                   "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                                 }
                               }
                             }
@@ -1722,21 +1461,18 @@
                           "version": "1.4.0",
                           "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                          "dev": true,
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.2",
                               "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                             }
                           }
                         },
                         "path-is-absolute": {
                           "version": "1.0.0",
                           "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                         }
                       }
                     }
@@ -1748,137 +1484,116 @@
               "version": "1.6.2",
               "from": "https://registry.npmjs.org/nugget/-/nugget-1.6.2.tgz",
               "resolved": "https://registry.npmjs.org/nugget/-/nugget-1.6.2.tgz",
-              "dev": true,
               "dependencies": {
                 "pretty-bytes": {
                   "version": "1.0.4",
                   "from": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
-                  "dev": true,
                   "dependencies": {
                     "get-stdin": {
                       "version": "4.0.1",
                       "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                     },
                     "meow": {
                       "version": "3.7.0",
                       "from": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
                       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-                      "dev": true,
                       "dependencies": {
                         "camelcase-keys": {
                           "version": "2.1.0",
                           "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-                          "dev": true,
                           "dependencies": {
                             "camelcase": {
                               "version": "2.1.1",
                               "from": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
                             }
                           }
                         },
                         "decamelize": {
                           "version": "1.2.0",
                           "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                         },
                         "loud-rejection": {
                           "version": "1.6.0",
                           "from": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
                           "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-                          "dev": true,
                           "dependencies": {
                             "currently-unhandled": {
                               "version": "0.4.1",
                               "from": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
                               "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-                              "dev": true,
                               "dependencies": {
                                 "array-find-index": {
                                   "version": "1.0.1",
                                   "from": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz"
                                 }
                               }
                             },
                             "signal-exit": {
                               "version": "3.0.1",
                               "from": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz"
                             }
                           }
                         },
                         "map-obj": {
                           "version": "1.0.1",
                           "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                         },
                         "normalize-package-data": {
                           "version": "2.3.5",
                           "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                           "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-                          "dev": true,
                           "dependencies": {
                             "hosted-git-info": {
                               "version": "2.1.5",
                               "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
-                              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz"
                             },
                             "is-builtin-module": {
                               "version": "1.0.0",
                               "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-                              "dev": true,
                               "dependencies": {
                                 "builtin-modules": {
                                   "version": "1.1.1",
                                   "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
                                 }
                               }
                             },
                             "semver": {
                               "version": "5.3.0",
                               "from": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-                              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
                             },
                             "validate-npm-package-license": {
                               "version": "3.0.1",
                               "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-                              "dev": true,
                               "dependencies": {
                                 "spdx-correct": {
                                   "version": "1.0.2",
                                   "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                                   "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-                                  "dev": true,
                                   "dependencies": {
                                     "spdx-license-ids": {
                                       "version": "1.2.2",
                                       "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-                                      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-                                      "dev": true
+                                      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
                                     }
                                   }
                                 },
                                 "spdx-expression-parse": {
                                   "version": "1.0.3",
                                   "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.3.tgz",
-                                  "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.3.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.3.tgz"
                                 }
                               }
                             }
@@ -1887,38 +1602,32 @@
                         "object-assign": {
                           "version": "4.1.0",
                           "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
                         },
                         "read-pkg-up": {
                           "version": "1.0.1",
                           "from": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-                          "dev": true,
                           "dependencies": {
                             "find-up": {
                               "version": "1.1.2",
                               "from": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                               "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-                              "dev": true,
                               "dependencies": {
                                 "path-exists": {
                                   "version": "2.1.0",
                                   "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
                                 },
                                 "pinkie-promise": {
                                   "version": "2.0.1",
                                   "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                                  "dev": true,
                                   "dependencies": {
                                     "pinkie": {
                                       "version": "2.0.4",
                                       "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                                      "dev": true
+                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                                     }
                                   }
                                 }
@@ -1928,37 +1637,31 @@
                               "version": "1.1.0",
                               "from": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-                              "dev": true,
                               "dependencies": {
                                 "load-json-file": {
                                   "version": "1.1.0",
                                   "from": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                                   "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-                                  "dev": true,
                                   "dependencies": {
                                     "graceful-fs": {
                                       "version": "4.1.8",
                                       "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.8.tgz",
-                                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.8.tgz",
-                                      "dev": true
+                                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.8.tgz"
                                     },
                                     "parse-json": {
                                       "version": "2.2.0",
                                       "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                                       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                                      "dev": true,
                                       "dependencies": {
                                         "error-ex": {
                                           "version": "1.3.0",
                                           "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
                                           "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-                                          "dev": true,
                                           "dependencies": {
                                             "is-arrayish": {
                                               "version": "0.2.1",
                                               "from": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-                                              "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-                                              "dev": true
+                                              "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
                                             }
                                           }
                                         }
@@ -1967,20 +1670,17 @@
                                     "pify": {
                                       "version": "2.3.0",
                                       "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                                      "dev": true
+                                      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                                     },
                                     "pinkie-promise": {
                                       "version": "2.0.1",
                                       "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                                       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                                      "dev": true,
                                       "dependencies": {
                                         "pinkie": {
                                           "version": "2.0.4",
                                           "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                                          "dev": true
+                                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                                         }
                                       }
                                     },
@@ -1988,13 +1688,11 @@
                                       "version": "2.0.0",
                                       "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-                                      "dev": true,
                                       "dependencies": {
                                         "is-utf8": {
                                           "version": "0.2.1",
                                           "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-                                          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-                                          "dev": true
+                                          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
                                         }
                                       }
                                     }
@@ -2004,31 +1702,26 @@
                                   "version": "1.1.0",
                                   "from": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                                   "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-                                  "dev": true,
                                   "dependencies": {
                                     "graceful-fs": {
                                       "version": "4.1.8",
                                       "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.8.tgz",
-                                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.8.tgz",
-                                      "dev": true
+                                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.8.tgz"
                                     },
                                     "pify": {
                                       "version": "2.3.0",
                                       "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                                      "dev": true
+                                      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                                     },
                                     "pinkie-promise": {
                                       "version": "2.0.1",
                                       "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                                       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                                      "dev": true,
                                       "dependencies": {
                                         "pinkie": {
                                           "version": "2.0.4",
                                           "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                                          "dev": true
+                                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                                         }
                                       }
                                     }
@@ -2042,31 +1735,26 @@
                           "version": "1.0.0",
                           "from": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-                          "dev": true,
                           "dependencies": {
                             "indent-string": {
                               "version": "2.1.0",
                               "from": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-                              "dev": true,
                               "dependencies": {
                                 "repeating": {
                                   "version": "2.0.1",
                                   "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-                                  "dev": true,
                                   "dependencies": {
                                     "is-finite": {
                                       "version": "1.0.1",
                                       "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                                       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                                      "dev": true,
                                       "dependencies": {
                                         "number-is-nan": {
                                           "version": "1.0.0",
                                           "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                                          "dev": true
+                                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                         }
                                       }
                                     }
@@ -2077,16 +1765,14 @@
                             "strip-indent": {
                               "version": "1.0.1",
                               "from": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
                             }
                           }
                         },
                         "trim-newlines": {
                           "version": "1.0.0",
                           "from": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
                         }
                       }
                     }
@@ -2096,49 +1782,41 @@
                   "version": "1.2.0",
                   "from": "https://registry.npmjs.org/progress-stream/-/progress-stream-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-1.2.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "speedometer": {
                       "version": "0.1.4",
                       "from": "https://registry.npmjs.org/speedometer/-/speedometer-0.1.4.tgz",
-                      "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-0.1.4.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-0.1.4.tgz"
                     },
                     "through2": {
                       "version": "0.2.3",
                       "from": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
                       "resolved": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
-                      "dev": true,
                       "dependencies": {
                         "readable-stream": {
                           "version": "1.1.14",
                           "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-                          "dev": true,
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.2",
                               "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                             },
                             "inherits": {
                               "version": "2.0.3",
                               "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                             },
                             "isarray": {
                               "version": "0.0.1",
                               "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                             },
                             "string_decoder": {
                               "version": "0.10.31",
                               "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             }
                           }
                         },
@@ -2146,13 +1824,11 @@
                           "version": "2.1.2",
                           "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
                           "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-                          "dev": true,
                           "dependencies": {
                             "object-keys": {
                               "version": "0.4.0",
                               "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-                              "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                             }
                           }
                         }
@@ -2164,67 +1840,56 @@
                   "version": "2.75.0",
                   "from": "https://registry.npmjs.org/request/-/request-2.75.0.tgz",
                   "resolved": "https://registry.npmjs.org/request/-/request-2.75.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "aws-sign2": {
                       "version": "0.6.0",
                       "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
                     },
                     "aws4": {
                       "version": "1.4.1",
                       "from": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz"
                     },
                     "bl": {
                       "version": "1.1.2",
                       "from": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-                      "dev": true,
                       "dependencies": {
                         "readable-stream": {
                           "version": "2.0.6",
                           "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                          "dev": true,
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.2",
                               "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                             },
                             "inherits": {
                               "version": "2.0.3",
                               "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                             },
                             "isarray": {
                               "version": "1.0.0",
                               "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                             },
                             "process-nextick-args": {
                               "version": "1.0.7",
                               "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                             },
                             "string_decoder": {
                               "version": "0.10.31",
                               "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             },
                             "util-deprecate": {
                               "version": "1.0.2",
                               "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                             }
                           }
                         }
@@ -2233,46 +1898,39 @@
                     "caseless": {
                       "version": "0.11.0",
                       "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
                     },
                     "combined-stream": {
                       "version": "1.0.5",
                       "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                      "dev": true,
                       "dependencies": {
                         "delayed-stream": {
                           "version": "1.0.0",
                           "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                         }
                       }
                     },
                     "extend": {
                       "version": "3.0.0",
                       "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
                     },
                     "forever-agent": {
                       "version": "0.6.1",
                       "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                     },
                     "form-data": {
                       "version": "2.0.0",
                       "from": "https://registry.npmjs.org/form-data/-/form-data-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.0.0.tgz",
-                      "dev": true,
                       "dependencies": {
                         "asynckit": {
                           "version": "0.4.0",
                           "from": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-                          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
                         }
                       }
                     },
@@ -2280,37 +1938,31 @@
                       "version": "2.0.6",
                       "from": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-                      "dev": true,
                       "dependencies": {
                         "chalk": {
                           "version": "1.1.3",
                           "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                          "dev": true,
                           "dependencies": {
                             "ansi-styles": {
                               "version": "2.2.1",
                               "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                             },
                             "escape-string-regexp": {
                               "version": "1.0.5",
                               "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                             },
                             "has-ansi": {
                               "version": "2.0.0",
                               "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "dev": true,
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
                                   "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
@@ -2318,21 +1970,18 @@
                               "version": "3.0.1",
                               "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                              "dev": true,
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
                                   "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "supports-color": {
                               "version": "2.0.0",
                               "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                             }
                           }
                         },
@@ -2340,13 +1989,11 @@
                           "version": "2.9.0",
                           "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                           "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                          "dev": true,
                           "dependencies": {
                             "graceful-readlink": {
                               "version": "1.0.1",
                               "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                             }
                           }
                         },
@@ -2354,39 +2001,33 @@
                           "version": "2.14.0",
                           "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.14.0.tgz",
                           "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.14.0.tgz",
-                          "dev": true,
                           "dependencies": {
                             "generate-function": {
                               "version": "2.0.0",
                               "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                             },
                             "generate-object-property": {
                               "version": "1.2.0",
                               "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                               "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                              "dev": true,
                               "dependencies": {
                                 "is-property": {
                                   "version": "1.0.2",
                                   "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                                 }
                               }
                             },
                             "jsonpointer": {
                               "version": "2.0.0",
                               "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                             },
                             "xtend": {
                               "version": "4.0.1",
                               "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                             }
                           }
                         },
@@ -2394,13 +2035,11 @@
                           "version": "2.0.1",
                           "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                          "dev": true,
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.4",
                               "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                             }
                           }
                         }
@@ -2410,31 +2049,26 @@
                       "version": "3.1.3",
                       "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-                      "dev": true,
                       "dependencies": {
                         "boom": {
                           "version": "2.10.1",
                           "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
                         },
                         "cryptiles": {
                           "version": "2.0.5",
                           "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                         },
                         "hoek": {
                           "version": "2.16.3",
                           "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                         },
                         "sntp": {
                           "version": "1.0.9",
                           "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                         }
                       }
                     },
@@ -2442,37 +2076,31 @@
                       "version": "1.1.1",
                       "from": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-                      "dev": true,
                       "dependencies": {
                         "assert-plus": {
                           "version": "0.2.0",
                           "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
                         },
                         "jsprim": {
                           "version": "1.3.1",
                           "from": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
                           "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
-                          "dev": true,
                           "dependencies": {
                             "extsprintf": {
                               "version": "1.0.2",
                               "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                             },
                             "json-schema": {
                               "version": "0.2.3",
                               "from": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-                              "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
                             },
                             "verror": {
                               "version": "1.3.6",
                               "from": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-                              "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
                             }
                           }
                         },
@@ -2480,75 +2108,58 @@
                           "version": "1.10.0",
                           "from": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.0.tgz",
                           "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.0.tgz",
-                          "dev": true,
                           "dependencies": {
                             "asn1": {
                               "version": "0.2.3",
                               "from": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
                             },
                             "assert-plus": {
                               "version": "1.0.0",
                               "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                             },
                             "bcrypt-pbkdf": {
                               "version": "1.0.0",
                               "from": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
-                              "dev": true,
-                              "optional": true,
                               "dependencies": {
                                 "tweetnacl": {
                                   "version": "0.14.3",
                                   "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
-                                  "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
-                                  "dev": true,
-                                  "optional": true
+                                  "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
                                 }
                               }
                             },
                             "dashdash": {
                               "version": "1.14.0",
                               "from": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
-                              "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz"
                             },
                             "ecc-jsbn": {
                               "version": "0.1.1",
                               "from": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                              "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                              "dev": true,
-                              "optional": true
+                              "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                             },
                             "getpass": {
                               "version": "0.1.6",
                               "from": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-                              "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz"
                             },
                             "jodid25519": {
                               "version": "1.0.2",
                               "from": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                              "dev": true,
-                              "optional": true
+                              "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
                             },
                             "jsbn": {
                               "version": "0.1.0",
                               "from": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-                              "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-                              "dev": true,
-                              "optional": true
+                              "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                             },
                             "tweetnacl": {
                               "version": "0.13.3",
                               "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
-                              "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
-                              "dev": true,
-                              "optional": true
+                              "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
                             }
                           }
                         }
@@ -2557,116 +2168,98 @@
                     "is-typedarray": {
                       "version": "1.0.0",
                       "from": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
                     },
                     "isstream": {
                       "version": "0.1.2",
                       "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                     },
                     "json-stringify-safe": {
                       "version": "5.0.1",
                       "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                     },
                     "mime-types": {
                       "version": "2.1.12",
                       "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
-                      "dev": true,
                       "dependencies": {
                         "mime-db": {
                           "version": "1.24.0",
                           "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                         }
                       }
                     },
                     "node-uuid": {
                       "version": "1.4.7",
                       "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
                     },
                     "oauth-sign": {
                       "version": "0.8.2",
                       "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
                     },
                     "qs": {
                       "version": "6.2.1",
                       "from": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz"
                     },
                     "stringstream": {
                       "version": "0.0.5",
                       "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
                     },
                     "tough-cookie": {
                       "version": "2.3.1",
                       "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
-                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz"
                     },
                     "tunnel-agent": {
                       "version": "0.4.3",
                       "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
                     }
                   }
                 },
                 "single-line-log": {
                   "version": "0.4.1",
                   "from": "https://registry.npmjs.org/single-line-log/-/single-line-log-0.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-0.4.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-0.4.1.tgz"
                 },
                 "throttleit": {
                   "version": "0.0.2",
                   "from": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
                 }
               }
             },
             "path-exists": {
               "version": "1.0.0",
               "from": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
             },
             "rc": {
               "version": "1.1.6",
               "from": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
               "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
-              "dev": true,
               "dependencies": {
                 "deep-extend": {
                   "version": "0.4.1",
                   "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
                 },
                 "ini": {
                   "version": "1.3.4",
                   "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                 },
                 "strip-json-comments": {
                   "version": "1.0.4",
                   "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
                 }
               }
             }
@@ -2675,90 +2268,76 @@
         "electron-osx-sign": {
           "version": "0.3.2",
           "from": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.3.2.tgz",
-          "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.3.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.3.2.tgz"
         },
         "extract-zip": {
           "version": "1.5.0",
           "from": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.5.0.tgz",
           "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.5.0.tgz",
-          "dev": true,
           "dependencies": {
             "concat-stream": {
               "version": "1.5.0",
               "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
               "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
-              "dev": true,
               "dependencies": {
                 "inherits": {
                   "version": "2.0.3",
                   "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "readable-stream": {
                   "version": "2.0.6",
                   "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                  "dev": true,
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
                       "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "1.0.0",
                       "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.7",
                       "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
                       "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
                       "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
                 },
                 "typedarray": {
                   "version": "0.0.6",
                   "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                 }
               }
             },
             "debug": {
               "version": "0.7.4",
               "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
             },
             "mkdirp": {
               "version": "0.5.0",
               "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-              "dev": true,
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
                   "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
@@ -2766,19 +2345,16 @@
               "version": "2.4.1",
               "from": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
               "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
-              "dev": true,
               "dependencies": {
                 "fd-slicer": {
                   "version": "1.0.1",
                   "from": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-                  "dev": true,
                   "dependencies": {
                     "pend": {
                       "version": "1.2.0",
                       "from": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-                      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
                     }
                   }
                 }
@@ -2790,93 +2366,78 @@
           "version": "0.30.0",
           "from": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-          "dev": true,
           "dependencies": {
             "graceful-fs": {
               "version": "4.1.8",
               "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.8.tgz",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.8.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.8.tgz"
             },
             "jsonfile": {
               "version": "2.4.0",
               "from": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz"
             },
             "klaw": {
               "version": "1.3.0",
               "from": "https://registry.npmjs.org/klaw/-/klaw-1.3.0.tgz",
-              "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.0.tgz"
             },
             "path-is-absolute": {
               "version": "1.0.0",
               "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             },
             "rimraf": {
               "version": "2.5.4",
               "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-              "dev": true,
               "dependencies": {
                 "glob": {
                   "version": "7.1.0",
                   "from": "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "fs.realpath": {
                       "version": "1.0.0",
                       "from": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
                     },
                     "inflight": {
                       "version": "1.0.5",
                       "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-                      "dev": true,
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
                           "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.3",
                       "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     },
                     "minimatch": {
                       "version": "3.0.3",
                       "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                      "dev": true,
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.6",
                           "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                          "dev": true,
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.4.2",
                               "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                             },
                             "concat-map": {
                               "version": "0.0.1",
                               "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                             }
                           }
                         }
@@ -2886,13 +2447,11 @@
                       "version": "1.4.0",
                       "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                      "dev": true,
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
                           "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                         }
                       }
                     }
@@ -2906,85 +2465,72 @@
           "version": "0.1.0",
           "from": "https://registry.npmjs.org/get-package-info/-/get-package-info-0.1.0.tgz",
           "resolved": "https://registry.npmjs.org/get-package-info/-/get-package-info-0.1.0.tgz",
-          "dev": true,
           "dependencies": {
             "bluebird": {
               "version": "3.4.6",
               "from": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.6.tgz",
-              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.6.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.6.tgz"
             },
             "lodash.get": {
               "version": "4.4.2",
               "from": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-              "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz"
             }
           }
         },
         "minimist": {
           "version": "1.2.0",
           "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         },
         "plist": {
           "version": "1.2.0",
           "from": "https://registry.npmjs.org/plist/-/plist-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/plist/-/plist-1.2.0.tgz",
-          "dev": true,
           "dependencies": {
             "base64-js": {
               "version": "0.0.8",
               "from": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
-              "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
             },
             "util-deprecate": {
               "version": "1.0.2",
               "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
             },
             "xmlbuilder": {
               "version": "4.0.0",
               "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.0.0.tgz",
               "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.0.0.tgz",
-              "dev": true,
               "dependencies": {
                 "lodash": {
                   "version": "3.10.1",
                   "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 }
               }
             },
             "xmldom": {
               "version": "0.1.22",
               "from": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.22.tgz",
-              "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.22.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.22.tgz"
             }
           }
         },
         "rcedit": {
           "version": "0.5.1",
           "from": "https://registry.npmjs.org/rcedit/-/rcedit-0.5.1.tgz",
-          "resolved": "https://registry.npmjs.org/rcedit/-/rcedit-0.5.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/rcedit/-/rcedit-0.5.1.tgz"
         },
         "resolve": {
           "version": "1.1.7",
           "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
         },
         "run-series": {
           "version": "1.1.4",
           "from": "https://registry.npmjs.org/run-series/-/run-series-1.1.4.tgz",
-          "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.4.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.4.tgz"
         }
       }
     },
@@ -2992,55 +2538,46 @@
       "version": "1.5.7",
       "from": "electron-rebuild@latest",
       "resolved": "https://registry.npmjs.org/electron-rebuild/-/electron-rebuild-1.5.7.tgz",
-      "dev": true,
       "dependencies": {
         "babel-register": {
           "version": "6.22.0",
           "from": "babel-register@>=6.16.3 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.22.0.tgz",
-          "dev": true,
           "dependencies": {
             "babel-core": {
               "version": "6.22.1",
               "from": "babel-core@>=6.22.0 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.22.1.tgz",
-              "dev": true,
               "dependencies": {
                 "babel-code-frame": {
                   "version": "6.22.0",
                   "from": "babel-code-frame@>=6.22.0 <7.0.0",
                   "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "chalk": {
                       "version": "1.1.3",
                       "from": "chalk@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                      "dev": true,
                       "dependencies": {
                         "ansi-styles": {
                           "version": "2.2.1",
                           "from": "ansi-styles@>=2.2.1 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                         },
                         "escape-string-regexp": {
                           "version": "1.0.5",
                           "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                         },
                         "has-ansi": {
                           "version": "2.0.0",
                           "from": "has-ansi@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                          "dev": true,
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.1.1",
                               "from": "ansi-regex@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                             }
                           }
                         },
@@ -3048,35 +2585,30 @@
                           "version": "3.0.1",
                           "from": "strip-ansi@>=3.0.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                          "dev": true,
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.1.1",
                               "from": "ansi-regex@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                             }
                           }
                         },
                         "supports-color": {
                           "version": "2.0.0",
                           "from": "supports-color@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                         }
                       }
                     },
                     "esutils": {
                       "version": "2.0.2",
                       "from": "esutils@>=2.0.2 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                     },
                     "js-tokens": {
                       "version": "3.0.1",
                       "from": "js-tokens@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
                     }
                   }
                 },
@@ -3084,31 +2616,26 @@
                   "version": "6.22.0",
                   "from": "babel-generator@>=6.22.0 <7.0.0",
                   "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.22.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "detect-indent": {
                       "version": "4.0.0",
                       "from": "detect-indent@>=4.0.0 <5.0.0",
                       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-                      "dev": true,
                       "dependencies": {
                         "repeating": {
                           "version": "2.0.1",
                           "from": "repeating@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-                          "dev": true,
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.2",
                               "from": "is-finite@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-                              "dev": true,
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.1",
                                   "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
                                 }
                               }
                             }
@@ -3119,58 +2646,49 @@
                     "jsesc": {
                       "version": "1.3.0",
                       "from": "jsesc@>=1.3.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz"
                     }
                   }
                 },
                 "babel-helpers": {
                   "version": "6.22.0",
                   "from": "babel-helpers@>=6.22.0 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.22.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.22.0.tgz"
                 },
                 "babel-messages": {
                   "version": "6.22.0",
                   "from": "babel-messages@>=6.22.0 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.22.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.22.0.tgz"
                 },
                 "babel-template": {
                   "version": "6.22.0",
                   "from": "babel-template@>=6.22.0 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.22.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.22.0.tgz"
                 },
                 "babel-traverse": {
                   "version": "6.22.1",
                   "from": "babel-traverse@>=6.22.1 <7.0.0",
                   "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.22.1.tgz",
-                  "dev": true,
                   "dependencies": {
                     "globals": {
                       "version": "9.14.0",
                       "from": "globals@>=9.0.0 <10.0.0",
-                      "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz"
                     },
                     "invariant": {
                       "version": "2.2.2",
                       "from": "invariant@>=2.2.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                      "dev": true,
                       "dependencies": {
                         "loose-envify": {
                           "version": "1.3.1",
                           "from": "loose-envify@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-                          "dev": true,
                           "dependencies": {
                             "js-tokens": {
                               "version": "3.0.1",
                               "from": "js-tokens@>=3.0.0 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
                             }
                           }
                         }
@@ -3182,63 +2700,53 @@
                   "version": "6.22.0",
                   "from": "babel-types@>=6.22.0 <7.0.0",
                   "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.22.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "esutils": {
                       "version": "2.0.2",
                       "from": "esutils@>=2.0.2 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                     },
                     "to-fast-properties": {
                       "version": "1.0.2",
                       "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
                     }
                   }
                 },
                 "babylon": {
                   "version": "6.15.0",
                   "from": "babylon@>=6.11.0 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.15.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.15.0.tgz"
                 },
                 "convert-source-map": {
                   "version": "1.3.0",
                   "from": "convert-source-map@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz"
                 },
                 "json5": {
                   "version": "0.5.1",
                   "from": "json5@>=0.5.0 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
                 },
                 "minimatch": {
                   "version": "3.0.3",
                   "from": "minimatch@>=3.0.2 <4.0.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                  "dev": true,
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.6",
                       "from": "brace-expansion@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                      "dev": true,
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.4.2",
                           "from": "balanced-match@>=0.4.1 <0.5.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
                           "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
                     }
@@ -3247,26 +2755,22 @@
                 "path-is-absolute": {
                   "version": "1.0.1",
                   "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
                 },
                 "private": {
                   "version": "0.1.7",
                   "from": "private@>=0.1.6 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz"
                 },
                 "slash": {
                   "version": "1.0.0",
                   "from": "slash@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
                 },
                 "source-map": {
                   "version": "0.5.6",
                   "from": "source-map@>=0.5.0 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
                 }
               }
             },
@@ -3274,59 +2778,50 @@
               "version": "6.22.0",
               "from": "babel-runtime@>=6.22.0 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz",
-              "dev": true,
               "dependencies": {
                 "regenerator-runtime": {
                   "version": "0.10.1",
                   "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.1.tgz"
                 }
               }
             },
             "core-js": {
               "version": "2.4.1",
               "from": "core-js@>=2.4.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
             },
             "home-or-tmp": {
               "version": "2.0.0",
               "from": "home-or-tmp@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-              "dev": true,
               "dependencies": {
                 "os-homedir": {
                   "version": "1.0.2",
                   "from": "os-homedir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
                 },
                 "os-tmpdir": {
                   "version": "1.0.2",
                   "from": "os-tmpdir@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
                 }
               }
             },
             "lodash": {
               "version": "4.17.4",
               "from": "lodash@>=4.2.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
             },
             "mkdirp": {
               "version": "0.5.1",
               "from": "mkdirp@>=0.5.1 <0.6.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "dev": true,
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
                   "from": "minimist@0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
@@ -3334,13 +2829,11 @@
               "version": "0.4.11",
               "from": "source-map-support@>=0.4.2 <0.5.0",
               "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.11.tgz",
-              "dev": true,
               "dependencies": {
                 "source-map": {
                   "version": "0.5.6",
                   "from": "source-map@>=0.5.3 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
                 }
               }
             }
@@ -3350,45 +2843,38 @@
           "version": "6.18.0",
           "from": "babel-runtime@6.18.0",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-          "dev": true,
           "dependencies": {
             "core-js": {
               "version": "2.4.1",
               "from": "core-js@>=2.4.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
             },
             "regenerator-runtime": {
               "version": "0.9.6",
               "from": "regenerator-runtime@>=0.9.5 <0.10.0",
-              "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz"
             }
           }
         },
         "bluebird": {
           "version": "3.4.7",
           "from": "bluebird@>=3.4.6 <4.0.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz"
         },
         "colors": {
           "version": "1.1.2",
           "from": "colors@>=1.1.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
         },
         "debug": {
           "version": "2.6.1",
           "from": "debug@>=2.4.5 <3.0.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.1.tgz",
-          "dev": true,
           "dependencies": {
             "ms": {
               "version": "0.7.2",
               "from": "ms@0.7.2",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
             }
           }
         },
@@ -3396,37 +2882,31 @@
           "version": "1.0.0",
           "from": "fs-promise@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/fs-promise/-/fs-promise-1.0.0.tgz",
-          "dev": true,
           "dependencies": {
             "any-promise": {
               "version": "1.3.0",
               "from": "any-promise@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz"
             },
             "fs-extra": {
               "version": "1.0.0",
               "from": "fs-extra@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
-              "dev": true,
               "dependencies": {
                 "graceful-fs": {
                   "version": "4.1.11",
                   "from": "graceful-fs@>=4.1.2 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
                 },
                 "jsonfile": {
                   "version": "2.4.0",
                   "from": "jsonfile@>=2.1.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz"
                 },
                 "klaw": {
                   "version": "1.3.1",
                   "from": "klaw@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz"
                 }
               }
             },
@@ -3434,13 +2914,11 @@
               "version": "2.6.0",
               "from": "mz@>=2.3.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/mz/-/mz-2.6.0.tgz",
-              "dev": true,
               "dependencies": {
                 "object-assign": {
                   "version": "4.1.1",
                   "from": "object-assign@>=4.0.1 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
                 }
               }
             },
@@ -3448,13 +2926,11 @@
               "version": "1.6.0",
               "from": "thenify-all@>=1.6.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-              "dev": true,
               "dependencies": {
                 "thenify": {
                   "version": "3.2.1",
                   "from": "thenify@>=3.1.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.2.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.2.1.tgz"
                 }
               }
             }
@@ -3463,26 +2939,22 @@
         "node-abi": {
           "version": "1.3.3",
           "from": "node-abi@>=1.0.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-1.3.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-1.3.3.tgz"
         },
         "node-gyp": {
           "version": "3.5.0",
           "from": "node-gyp@>=3.4.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.5.0.tgz",
-          "dev": true,
           "dependencies": {
             "fstream": {
               "version": "1.0.10",
               "from": "fstream@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
-              "dev": true,
               "dependencies": {
                 "inherits": {
                   "version": "2.0.3",
                   "from": "inherits@>=2.0.0 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 }
               }
             },
@@ -3490,85 +2962,72 @@
               "version": "7.1.1",
               "from": "glob@>=7.0.3 <8.0.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-              "dev": true,
               "dependencies": {
                 "fs.realpath": {
                   "version": "1.0.0",
                   "from": "fs.realpath@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
                 },
                 "inflight": {
                   "version": "1.0.6",
                   "from": "inflight@>=1.0.4 <2.0.0",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                  "dev": true,
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.2",
                       "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.3",
                   "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "once": {
                   "version": "1.4.0",
                   "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.2",
                       "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 },
                 "path-is-absolute": {
                   "version": "1.0.1",
                   "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
                 }
               }
             },
             "graceful-fs": {
               "version": "4.1.11",
               "from": "graceful-fs@>=4.1.2 <5.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
             },
             "minimatch": {
               "version": "3.0.3",
               "from": "minimatch@>=3.0.2 <4.0.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-              "dev": true,
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.6",
                   "from": "brace-expansion@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                  "dev": true,
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.4.2",
                       "from": "balanced-match@>=0.4.1 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
                       "from": "concat-map@0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
                 }
@@ -3578,13 +3037,11 @@
               "version": "0.5.1",
               "from": "mkdirp@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "dev": true,
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
                   "from": "minimist@0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
@@ -3592,13 +3049,11 @@
               "version": "3.0.6",
               "from": "nopt@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-              "dev": true,
               "dependencies": {
                 "abbrev": {
                   "version": "1.0.9",
                   "from": "abbrev@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
                 }
               }
             },
@@ -3606,67 +3061,56 @@
               "version": "4.0.2",
               "from": "npmlog@>=0.0.0 <1.0.0||>=1.0.0 <2.0.0||>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
-              "dev": true,
               "dependencies": {
                 "are-we-there-yet": {
                   "version": "1.1.2",
                   "from": "are-we-there-yet@>=1.1.2 <1.2.0",
                   "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
-                  "dev": true,
                   "dependencies": {
                     "delegates": {
                       "version": "1.0.0",
                       "from": "delegates@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
                     },
                     "readable-stream": {
                       "version": "2.2.2",
                       "from": "readable-stream@>=2.0.0 <3.0.0||>=1.1.13 <2.0.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
-                      "dev": true,
                       "dependencies": {
                         "buffer-shims": {
                           "version": "1.0.0",
                           "from": "buffer-shims@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
                         },
                         "core-util-is": {
                           "version": "1.0.2",
                           "from": "core-util-is@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "inherits": {
                           "version": "2.0.3",
                           "from": "inherits@>=2.0.1 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                         },
                         "isarray": {
                           "version": "1.0.0",
                           "from": "isarray@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                         },
                         "process-nextick-args": {
                           "version": "1.0.7",
                           "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
                           "from": "string_decoder@>=0.10.0 <0.11.0",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
                           "from": "util-deprecate@>=1.0.1 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                         }
                       }
                     }
@@ -3675,62 +3119,52 @@
                 "console-control-strings": {
                   "version": "1.1.0",
                   "from": "console-control-strings@>=1.1.0 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
                 },
                 "gauge": {
                   "version": "2.7.3",
                   "from": "gauge@>=2.7.1 <2.8.0",
                   "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.3.tgz",
-                  "dev": true,
                   "dependencies": {
                     "aproba": {
                       "version": "1.1.1",
                       "from": "aproba@>=1.0.3 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz"
                     },
                     "has-unicode": {
                       "version": "2.0.1",
                       "from": "has-unicode@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
                     },
                     "object-assign": {
                       "version": "4.1.1",
                       "from": "object-assign@>=4.1.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
                     },
                     "signal-exit": {
                       "version": "3.0.2",
                       "from": "signal-exit@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
                     },
                     "string-width": {
                       "version": "1.0.2",
                       "from": "string-width@>=1.0.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                      "dev": true,
                       "dependencies": {
                         "code-point-at": {
                           "version": "1.1.0",
                           "from": "code-point-at@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
                         },
                         "is-fullwidth-code-point": {
                           "version": "1.0.0",
                           "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                          "dev": true,
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.1",
                               "from": "number-is-nan@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
                             }
                           }
                         }
@@ -3740,29 +3174,25 @@
                       "version": "3.0.1",
                       "from": "strip-ansi@>=3.0.1 <4.0.0",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                      "dev": true,
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.1.1",
                           "from": "ansi-regex@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                         }
                       }
                     },
                     "wide-align": {
                       "version": "1.1.0",
                       "from": "wide-align@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
                     }
                   }
                 },
                 "set-blocking": {
                   "version": "2.0.0",
                   "from": "set-blocking@>=2.0.0 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
                 }
               }
             },
@@ -3770,19 +3200,16 @@
               "version": "0.1.4",
               "from": "osenv@>=0.0.0 <1.0.0",
               "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-              "dev": true,
               "dependencies": {
                 "os-homedir": {
                   "version": "1.0.2",
                   "from": "os-homedir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
                 },
                 "os-tmpdir": {
                   "version": "1.0.2",
                   "from": "os-tmpdir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
                 }
               }
             },
@@ -3790,63 +3217,53 @@
               "version": "2.79.0",
               "from": "request@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-              "dev": true,
               "dependencies": {
                 "aws-sign2": {
                   "version": "0.6.0",
                   "from": "aws-sign2@>=0.6.0 <0.7.0",
-                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
                 },
                 "aws4": {
                   "version": "1.6.0",
                   "from": "aws4@>=1.2.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
                 },
                 "caseless": {
                   "version": "0.11.0",
                   "from": "caseless@>=0.11.0 <0.12.0",
-                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
                 },
                 "combined-stream": {
                   "version": "1.0.5",
                   "from": "combined-stream@>=1.0.5 <1.1.0",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                  "dev": true,
                   "dependencies": {
                     "delayed-stream": {
                       "version": "1.0.0",
                       "from": "delayed-stream@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                     }
                   }
                 },
                 "extend": {
                   "version": "3.0.0",
                   "from": "extend@>=3.0.0 <3.1.0",
-                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.6.1",
                   "from": "forever-agent@>=0.6.1 <0.7.0",
-                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                 },
                 "form-data": {
                   "version": "2.1.2",
                   "from": "form-data@>=2.1.1 <2.2.0",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
-                  "dev": true,
                   "dependencies": {
                     "asynckit": {
                       "version": "0.4.0",
                       "from": "asynckit@>=0.4.0 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
                     }
                   }
                 },
@@ -3854,37 +3271,31 @@
                   "version": "2.0.6",
                   "from": "har-validator@>=2.0.6 <2.1.0",
                   "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-                  "dev": true,
                   "dependencies": {
                     "chalk": {
                       "version": "1.1.3",
                       "from": "chalk@>=1.1.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                      "dev": true,
                       "dependencies": {
                         "ansi-styles": {
                           "version": "2.2.1",
                           "from": "ansi-styles@>=2.2.1 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                         },
                         "escape-string-regexp": {
                           "version": "1.0.5",
                           "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                         },
                         "has-ansi": {
                           "version": "2.0.0",
                           "from": "has-ansi@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                          "dev": true,
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.1.1",
                               "from": "ansi-regex@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                             }
                           }
                         },
@@ -3892,21 +3303,18 @@
                           "version": "3.0.1",
                           "from": "strip-ansi@>=3.0.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                          "dev": true,
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.1.1",
                               "from": "ansi-regex@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                             }
                           }
                         },
                         "supports-color": {
                           "version": "2.0.0",
                           "from": "supports-color@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                         }
                       }
                     },
@@ -3914,13 +3322,11 @@
                       "version": "2.9.0",
                       "from": "commander@>=2.9.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                      "dev": true,
                       "dependencies": {
                         "graceful-readlink": {
                           "version": "1.0.1",
                           "from": "graceful-readlink@>=1.0.0",
-                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                         }
                       }
                     },
@@ -3928,39 +3334,33 @@
                       "version": "2.15.0",
                       "from": "is-my-json-valid@>=2.12.4 <3.0.0",
                       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
-                      "dev": true,
                       "dependencies": {
                         "generate-function": {
                           "version": "2.0.0",
                           "from": "generate-function@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                         },
                         "generate-object-property": {
                           "version": "1.2.0",
                           "from": "generate-object-property@>=1.1.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                          "dev": true,
                           "dependencies": {
                             "is-property": {
                               "version": "1.0.2",
                               "from": "is-property@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                             }
                           }
                         },
                         "jsonpointer": {
                           "version": "4.0.1",
                           "from": "jsonpointer@>=4.0.0 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz"
                         },
                         "xtend": {
                           "version": "4.0.1",
                           "from": "xtend@>=4.0.0 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                         }
                       }
                     },
@@ -3968,13 +3368,11 @@
                       "version": "2.0.1",
                       "from": "pinkie-promise@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                      "dev": true,
                       "dependencies": {
                         "pinkie": {
                           "version": "2.0.4",
                           "from": "pinkie@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                         }
                       }
                     }
@@ -3984,31 +3382,26 @@
                   "version": "3.1.3",
                   "from": "hawk@>=3.1.3 <3.2.0",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-                  "dev": true,
                   "dependencies": {
                     "boom": {
                       "version": "2.10.1",
                       "from": "boom@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
                     },
                     "cryptiles": {
                       "version": "2.0.5",
                       "from": "cryptiles@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                     },
                     "hoek": {
                       "version": "2.16.3",
                       "from": "hoek@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                     },
                     "sntp": {
                       "version": "1.0.9",
                       "from": "sntp@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                     }
                   }
                 },
@@ -4016,37 +3409,31 @@
                   "version": "1.1.1",
                   "from": "http-signature@>=1.1.0 <1.2.0",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-                  "dev": true,
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.2.0",
                       "from": "assert-plus@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
                     },
                     "jsprim": {
                       "version": "1.3.1",
                       "from": "jsprim@>=1.2.2 <2.0.0",
                       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
-                      "dev": true,
                       "dependencies": {
                         "extsprintf": {
                           "version": "1.0.2",
                           "from": "extsprintf@1.0.2",
-                          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                         },
                         "json-schema": {
                           "version": "0.2.3",
                           "from": "json-schema@0.2.3",
-                          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
                         },
                         "verror": {
                           "version": "1.3.6",
                           "from": "verror@1.3.6",
-                          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
                         }
                       }
                     },
@@ -4054,66 +3441,51 @@
                       "version": "1.10.2",
                       "from": "sshpk@>=1.7.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.2.tgz",
-                      "dev": true,
                       "dependencies": {
                         "asn1": {
                           "version": "0.2.3",
                           "from": "asn1@>=0.2.3 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
                         },
                         "assert-plus": {
                           "version": "1.0.0",
                           "from": "assert-plus@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                         },
                         "bcrypt-pbkdf": {
                           "version": "1.0.1",
                           "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-                          "dev": true,
-                          "optional": true
+                          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz"
                         },
                         "dashdash": {
                           "version": "1.14.1",
                           "from": "dashdash@>=1.12.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
                         },
                         "ecc-jsbn": {
                           "version": "0.1.1",
                           "from": "ecc-jsbn@>=0.1.1 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                          "dev": true,
-                          "optional": true
+                          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                         },
                         "getpass": {
                           "version": "0.1.6",
                           "from": "getpass@>=0.1.1 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz"
                         },
                         "jodid25519": {
                           "version": "1.0.2",
                           "from": "jodid25519@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                          "dev": true,
-                          "optional": true
+                          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
                         },
                         "jsbn": {
                           "version": "0.1.0",
                           "from": "jsbn@>=0.1.0 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-                          "dev": true,
-                          "optional": true
+                          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                         },
                         "tweetnacl": {
                           "version": "0.14.5",
                           "from": "tweetnacl@>=0.14.0 <0.15.0",
-                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-                          "dev": true,
-                          "optional": true
+                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
                         }
                       }
                     }
@@ -4122,104 +3494,88 @@
                 "is-typedarray": {
                   "version": "1.0.0",
                   "from": "is-typedarray@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
                 },
                 "isstream": {
                   "version": "0.1.2",
                   "from": "isstream@>=0.1.2 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
                   "from": "json-stringify-safe@>=5.0.1 <5.1.0",
-                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                 },
                 "mime-types": {
                   "version": "2.1.14",
                   "from": "mime-types@>=2.1.7 <2.2.0",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
-                  "dev": true,
                   "dependencies": {
                     "mime-db": {
                       "version": "1.26.0",
                       "from": "mime-db@>=1.26.0 <1.27.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz"
                     }
                   }
                 },
                 "oauth-sign": {
                   "version": "0.8.2",
                   "from": "oauth-sign@>=0.8.1 <0.9.0",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
                 },
                 "qs": {
                   "version": "6.3.0",
                   "from": "qs@>=6.3.0 <6.4.0",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.5",
                   "from": "stringstream@>=0.0.4 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
                 },
                 "tough-cookie": {
                   "version": "2.3.2",
                   "from": "tough-cookie@>=2.3.0 <2.4.0",
                   "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-                  "dev": true,
                   "dependencies": {
                     "punycode": {
                       "version": "1.4.1",
                       "from": "punycode@>=1.4.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
                     }
                   }
                 },
                 "tunnel-agent": {
                   "version": "0.4.3",
                   "from": "tunnel-agent@>=0.4.1 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
                 },
                 "uuid": {
                   "version": "3.0.1",
                   "from": "uuid@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
                 }
               }
             },
             "semver": {
               "version": "5.3.0",
               "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
             },
             "tar": {
               "version": "2.2.1",
               "from": "tar@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-              "dev": true,
               "dependencies": {
                 "block-stream": {
                   "version": "0.0.9",
                   "from": "block-stream@*",
-                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
                 },
                 "inherits": {
                   "version": "2.0.3",
                   "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 }
               }
             },
@@ -4227,13 +3583,11 @@
               "version": "1.2.12",
               "from": "which@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
-              "dev": true,
               "dependencies": {
                 "isexe": {
                   "version": "1.1.2",
                   "from": "isexe@>=1.1.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
                 }
               }
             }
@@ -4243,37 +3597,31 @@
           "version": "0.3.0",
           "from": "ora@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/ora/-/ora-0.3.0.tgz",
-          "dev": true,
           "dependencies": {
             "chalk": {
               "version": "1.1.3",
               "from": "chalk@>=1.1.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "dev": true,
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.2.1",
                   "from": "ansi-styles@>=2.2.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.5",
                   "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
                   "from": "has-ansi@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
                       "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                     }
                   }
                 },
@@ -4281,21 +3629,18 @@
                   "version": "3.0.1",
                   "from": "strip-ansi@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "dev": true,
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
                       "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
                   "from": "supports-color@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
@@ -4303,25 +3648,21 @@
               "version": "1.0.2",
               "from": "cli-cursor@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-              "dev": true,
               "dependencies": {
                 "restore-cursor": {
                   "version": "1.0.1",
                   "from": "restore-cursor@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-                  "dev": true,
                   "dependencies": {
                     "exit-hook": {
                       "version": "1.1.1",
                       "from": "exit-hook@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz"
                     },
                     "onetime": {
                       "version": "1.1.0",
                       "from": "onetime@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
                     }
                   }
                 }
@@ -4330,14 +3671,12 @@
             "cli-spinners": {
               "version": "0.2.0",
               "from": "cli-spinners@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.2.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.2.0.tgz"
             },
             "log-symbols": {
               "version": "1.0.2",
               "from": "log-symbols@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz"
             }
           }
         },
@@ -4345,63 +3684,53 @@
           "version": "2.5.4",
           "from": "rimraf@>=2.5.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-          "dev": true,
           "dependencies": {
             "glob": {
               "version": "7.1.1",
               "from": "glob@>=7.0.5 <8.0.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-              "dev": true,
               "dependencies": {
                 "fs.realpath": {
                   "version": "1.0.0",
                   "from": "fs.realpath@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
                 },
                 "inflight": {
                   "version": "1.0.6",
                   "from": "inflight@>=1.0.4 <2.0.0",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                  "dev": true,
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.2",
                       "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.3",
                   "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "minimatch": {
                   "version": "3.0.3",
                   "from": "minimatch@>=3.0.2 <4.0.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                  "dev": true,
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.6",
                       "from": "brace-expansion@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                      "dev": true,
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.4.2",
                           "from": "balanced-match@>=0.4.1 <0.5.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
                           "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
                     }
@@ -4411,21 +3740,18 @@
                   "version": "1.4.0",
                   "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.2",
                       "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 },
                 "path-is-absolute": {
                   "version": "1.0.1",
                   "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
                 }
               }
             }
@@ -4435,19 +3761,16 @@
           "version": "2.0.8",
           "from": "spawn-rx@>=2.0.7 <3.0.0",
           "resolved": "https://registry.npmjs.org/spawn-rx/-/spawn-rx-2.0.8.tgz",
-          "dev": true,
           "dependencies": {
             "rxjs": {
               "version": "5.1.0",
               "from": "rxjs@>=5.0.0-rc.5 <6.0.0",
               "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.1.0.tgz",
-              "dev": true,
               "dependencies": {
                 "symbol-observable": {
                   "version": "1.0.4",
                   "from": "symbol-observable@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz"
                 }
               }
             }
@@ -4457,65 +3780,55 @@
           "version": "3.32.0",
           "from": "yargs@>=3.31.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-          "dev": true,
           "dependencies": {
             "camelcase": {
               "version": "2.1.1",
               "from": "camelcase@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
             },
             "cliui": {
               "version": "3.2.0",
               "from": "cliui@>=3.0.3 <4.0.0",
               "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-              "dev": true,
               "dependencies": {
                 "strip-ansi": {
                   "version": "3.0.1",
                   "from": "strip-ansi@>=3.0.1 <4.0.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "dev": true,
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
                       "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                     }
                   }
                 },
                 "wrap-ansi": {
                   "version": "2.1.0",
                   "from": "wrap-ansi@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
                 }
               }
             },
             "decamelize": {
               "version": "1.2.0",
               "from": "decamelize@>=1.1.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
             },
             "os-locale": {
               "version": "1.4.0",
               "from": "os-locale@>=1.4.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-              "dev": true,
               "dependencies": {
                 "lcid": {
                   "version": "1.0.0",
                   "from": "lcid@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "invert-kv": {
                       "version": "1.0.0",
                       "from": "invert-kv@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
                     }
                   }
                 }
@@ -4525,25 +3838,21 @@
               "version": "1.0.2",
               "from": "string-width@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "dev": true,
               "dependencies": {
                 "code-point-at": {
                   "version": "1.1.0",
                   "from": "code-point-at@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
                 },
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
                   "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.1",
                       "from": "number-is-nan@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
                     }
                   }
                 },
@@ -4551,13 +3860,11 @@
                   "version": "3.0.1",
                   "from": "strip-ansi@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "dev": true,
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
                       "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                     }
                   }
                 }
@@ -4566,14 +3873,12 @@
             "window-size": {
               "version": "0.1.4",
               "from": "window-size@>=0.1.4 <0.2.0",
-              "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
             },
             "y18n": {
               "version": "3.2.1",
               "from": "y18n@>=3.2.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
             }
           }
         }
@@ -4582,256 +3887,216 @@
     "error-ex": {
       "version": "1.3.1",
       "from": "error-ex@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz"
     },
     "extend": {
       "version": "3.0.1",
       "from": "extend@>=3.0.0 <3.1.0",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
     },
     "extract-zip": {
       "version": "1.6.5",
       "from": "extract-zip@>=1.0.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.5.tgz",
-      "dev": true,
       "dependencies": {
         "debug": {
           "version": "2.2.0",
           "from": "debug@2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
         },
         "minimist": {
           "version": "0.0.8",
           "from": "minimist@0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
         },
         "mkdirp": {
           "version": "0.5.0",
           "from": "mkdirp@0.5.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz"
         },
         "ms": {
           "version": "0.7.1",
           "from": "ms@0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
         }
       }
     },
     "extsprintf": {
       "version": "1.0.2",
       "from": "extsprintf@1.0.2",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
     },
     "fd-slicer": {
       "version": "1.0.1",
       "from": "fd-slicer@>=1.0.1 <1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz"
     },
     "find-up": {
       "version": "1.1.2",
       "from": "find-up@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-      "dev": true,
       "dependencies": {
         "path-exists": {
           "version": "2.1.0",
           "from": "path-exists@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
         }
       }
     },
     "forever-agent": {
       "version": "0.6.1",
       "from": "forever-agent@>=0.6.1 <0.7.0",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
     },
     "form-data": {
       "version": "2.1.4",
       "from": "form-data@>=2.1.1 <2.2.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz"
     },
     "get-stdin": {
       "version": "4.0.1",
       "from": "get-stdin@>=4.0.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
     },
     "getpass": {
       "version": "0.1.7",
       "from": "getpass@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "dev": true,
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
           "from": "assert-plus@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
     },
     "glob": {
       "version": "6.0.4",
       "from": "glob@>=6.0.1 <7.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz"
     },
     "graceful-fs": {
       "version": "4.1.11",
       "from": "graceful-fs@>=4.1.2 <5.0.0",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
     },
     "grunt": {
       "version": "1.0.0",
       "from": "https://registry.npmjs.org/grunt/-/grunt-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.0.0.tgz",
-      "dev": true,
       "dependencies": {
         "coffee-script": {
           "version": "1.10.0",
           "from": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.10.0.tgz",
-          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.10.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.10.0.tgz"
         },
         "dateformat": {
           "version": "1.0.12",
           "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-          "dev": true,
           "dependencies": {
             "get-stdin": {
               "version": "4.0.1",
               "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
             },
             "meow": {
               "version": "3.7.0",
               "from": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
               "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-              "dev": true,
               "dependencies": {
                 "camelcase-keys": {
                   "version": "2.1.0",
                   "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "camelcase": {
                       "version": "2.1.1",
                       "from": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
                     }
                   }
                 },
                 "decamelize": {
                   "version": "1.2.0",
                   "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                 },
                 "loud-rejection": {
                   "version": "1.4.1",
                   "from": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.4.1.tgz",
                   "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.4.1.tgz",
-                  "dev": true,
                   "dependencies": {
                     "currently-unhandled": {
                       "version": "0.4.1",
                       "from": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
                       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-                      "dev": true,
                       "dependencies": {
                         "array-find-index": {
                           "version": "1.0.1",
                           "from": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz"
                         }
                       }
                     },
                     "signal-exit": {
                       "version": "2.1.2",
                       "from": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
                     }
                   }
                 },
                 "map-obj": {
                   "version": "1.0.1",
                   "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                 },
                 "minimist": {
                   "version": "1.2.0",
                   "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                 },
                 "normalize-package-data": {
                   "version": "2.3.5",
                   "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                   "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-                  "dev": true,
                   "dependencies": {
                     "hosted-git-info": {
                       "version": "2.1.5",
                       "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
-                      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz"
                     },
                     "is-builtin-module": {
                       "version": "1.0.0",
                       "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-                      "dev": true,
                       "dependencies": {
                         "builtin-modules": {
                           "version": "1.1.1",
                           "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-                          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
                         }
                       }
                     },
                     "semver": {
                       "version": "5.1.0",
                       "from": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
                     },
                     "validate-npm-package-license": {
                       "version": "3.0.1",
                       "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-                      "dev": true,
                       "dependencies": {
                         "spdx-correct": {
                           "version": "1.0.2",
                           "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-                          "dev": true,
                           "dependencies": {
                             "spdx-license-ids": {
                               "version": "1.2.1",
                               "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz",
-                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
                             }
                           }
                         },
@@ -4839,19 +4104,16 @@
                           "version": "1.0.2",
                           "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
-                          "dev": true,
                           "dependencies": {
                             "spdx-exceptions": {
                               "version": "1.0.4",
                               "from": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
-                              "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
                             },
                             "spdx-license-ids": {
                               "version": "1.2.1",
                               "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz",
-                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
                             }
                           }
                         }
@@ -4862,38 +4124,32 @@
                 "object-assign": {
                   "version": "4.1.0",
                   "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
                 },
                 "read-pkg-up": {
                   "version": "1.0.1",
                   "from": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-                  "dev": true,
                   "dependencies": {
                     "find-up": {
                       "version": "1.1.2",
                       "from": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-                      "dev": true,
                       "dependencies": {
                         "path-exists": {
                           "version": "2.1.0",
                           "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
                         },
                         "pinkie-promise": {
                           "version": "2.0.1",
                           "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                          "dev": true,
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.4",
                               "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                             }
                           }
                         }
@@ -4903,37 +4159,31 @@
                       "version": "1.1.0",
                       "from": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-                      "dev": true,
                       "dependencies": {
                         "load-json-file": {
                           "version": "1.1.0",
                           "from": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-                          "dev": true,
                           "dependencies": {
                             "graceful-fs": {
                               "version": "4.1.4",
                               "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
                             },
                             "parse-json": {
                               "version": "2.2.0",
                               "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                               "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                              "dev": true,
                               "dependencies": {
                                 "error-ex": {
                                   "version": "1.3.0",
                                   "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
                                   "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-                                  "dev": true,
                                   "dependencies": {
                                     "is-arrayish": {
                                       "version": "0.2.1",
                                       "from": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-                                      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-                                      "dev": true
+                                      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
                                     }
                                   }
                                 }
@@ -4942,20 +4192,17 @@
                             "pify": {
                               "version": "2.3.0",
                               "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                             },
                             "pinkie-promise": {
                               "version": "2.0.1",
                               "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                              "dev": true,
                               "dependencies": {
                                 "pinkie": {
                                   "version": "2.0.4",
                                   "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                                 }
                               }
                             },
@@ -4963,13 +4210,11 @@
                               "version": "2.0.0",
                               "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-                              "dev": true,
                               "dependencies": {
                                 "is-utf8": {
                                   "version": "0.2.1",
                                   "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
                                 }
                               }
                             }
@@ -4979,31 +4224,26 @@
                           "version": "1.1.0",
                           "from": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-                          "dev": true,
                           "dependencies": {
                             "graceful-fs": {
                               "version": "4.1.4",
                               "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
                             },
                             "pify": {
                               "version": "2.3.0",
                               "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                             },
                             "pinkie-promise": {
                               "version": "2.0.1",
                               "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                              "dev": true,
                               "dependencies": {
                                 "pinkie": {
                                   "version": "2.0.4",
                                   "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                                 }
                               }
                             }
@@ -5017,31 +4257,26 @@
                   "version": "1.0.0",
                   "from": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "indent-string": {
                       "version": "2.1.0",
                       "from": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-                      "dev": true,
                       "dependencies": {
                         "repeating": {
                           "version": "2.0.1",
                           "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-                          "dev": true,
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
                               "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                              "dev": true,
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.0",
                                   "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                 }
                               }
                             }
@@ -5052,16 +4287,14 @@
                     "strip-indent": {
                       "version": "1.0.1",
                       "from": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
                     }
                   }
                 },
                 "trim-newlines": {
                   "version": "1.0.0",
                   "from": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
                 }
               }
             }
@@ -5070,58 +4303,49 @@
         "eventemitter2": {
           "version": "0.4.14",
           "from": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
-          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
         },
         "exit": {
           "version": "0.1.2",
           "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "findup-sync": {
           "version": "0.3.0",
           "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
-          "dev": true,
           "dependencies": {
             "glob": {
               "version": "5.0.15",
               "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
               "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-              "dev": true,
               "dependencies": {
                 "inflight": {
                   "version": "1.0.5",
                   "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-                  "dev": true,
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.2",
                       "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
                   "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "once": {
                   "version": "1.3.3",
                   "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "dev": true,
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.2",
                       "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 }
@@ -5133,39 +4357,33 @@
           "version": "7.0.3",
           "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
-          "dev": true,
           "dependencies": {
             "inflight": {
               "version": "1.0.5",
               "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-              "dev": true,
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.2",
                   "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                 }
               }
             },
             "inherits": {
               "version": "2.0.1",
               "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "once": {
               "version": "1.3.3",
               "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-              "dev": true,
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.2",
                   "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                 }
               }
             }
@@ -5175,69 +4393,58 @@
           "version": "1.2.0",
           "from": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.2.0.tgz",
-          "dev": true,
           "dependencies": {
             "resolve": {
               "version": "1.1.7",
               "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
             }
           }
         },
         "grunt-known-options": {
           "version": "1.1.0",
           "from": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.0.tgz"
         },
         "grunt-legacy-log": {
           "version": "1.0.0",
           "from": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-1.0.0.tgz",
-          "dev": true,
           "dependencies": {
             "colors": {
               "version": "1.1.2",
               "from": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
             },
             "grunt-legacy-log-utils": {
               "version": "1.0.0",
               "from": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-1.0.0.tgz",
-              "dev": true,
               "dependencies": {
                 "chalk": {
                   "version": "1.1.3",
                   "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                  "dev": true,
                   "dependencies": {
                     "ansi-styles": {
                       "version": "2.2.1",
                       "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                     },
                     "escape-string-regexp": {
                       "version": "1.0.5",
                       "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                     },
                     "has-ansi": {
                       "version": "2.0.0",
                       "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                      "dev": true,
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
                           "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         }
                       }
                     },
@@ -5245,49 +4452,42 @@
                       "version": "3.0.1",
                       "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                      "dev": true,
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
                           "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         }
                       }
                     },
                     "supports-color": {
                       "version": "2.0.0",
                       "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                     }
                   }
                 },
                 "lodash": {
                   "version": "4.3.0",
                   "from": "https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz"
                 }
               }
             },
             "hooker": {
               "version": "0.2.3",
               "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
-              "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
             },
             "lodash": {
               "version": "3.10.1",
               "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
             },
             "underscore.string": {
               "version": "3.2.3",
               "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.2.3.tgz",
-              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.2.3.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.2.3.tgz"
             }
           }
         },
@@ -5295,49 +4495,41 @@
           "version": "1.0.0",
           "from": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-1.0.0.tgz",
-          "dev": true,
           "dependencies": {
             "async": {
               "version": "1.5.2",
               "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
             },
             "getobject": {
               "version": "0.1.0",
               "from": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
             },
             "hooker": {
               "version": "0.2.3",
               "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
-              "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
             },
             "lodash": {
               "version": "4.3.0",
               "from": "https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz"
             },
             "underscore.string": {
               "version": "3.2.3",
               "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.2.3.tgz",
-              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.2.3.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.2.3.tgz"
             },
             "which": {
               "version": "1.2.10",
               "from": "https://registry.npmjs.org/which/-/which-1.2.10.tgz",
               "resolved": "https://registry.npmjs.org/which/-/which-1.2.10.tgz",
-              "dev": true,
               "dependencies": {
                 "isexe": {
                   "version": "1.1.2",
                   "from": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
                 }
               }
             }
@@ -5346,34 +4538,29 @@
         "iconv-lite": {
           "version": "0.4.13",
           "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
         },
         "js-yaml": {
           "version": "3.5.5",
           "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz",
-          "dev": true,
           "dependencies": {
             "argparse": {
               "version": "1.0.7",
               "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
-              "dev": true,
               "dependencies": {
                 "sprintf-js": {
                   "version": "1.0.3",
                   "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
                 }
               }
             },
             "esprima": {
               "version": "2.7.2",
               "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
             }
           }
         },
@@ -5381,25 +4568,21 @@
           "version": "3.0.0",
           "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-          "dev": true,
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.4",
               "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
-              "dev": true,
               "dependencies": {
                 "balanced-match": {
                   "version": "0.4.1",
                   "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz"
                 },
                 "concat-map": {
                   "version": "0.0.1",
                   "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                 }
               }
             }
@@ -5409,258 +4592,215 @@
           "version": "3.0.6",
           "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "dev": true,
           "dependencies": {
             "abbrev": {
               "version": "1.0.7",
               "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
             }
           }
         },
         "path-is-absolute": {
           "version": "1.0.0",
           "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
         },
         "rimraf": {
           "version": "2.2.8",
           "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         }
       }
     },
     "har-schema": {
       "version": "1.0.5",
       "from": "har-schema@>=1.0.5 <2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
     },
     "har-validator": {
       "version": "4.2.1",
       "from": "har-validator@>=4.2.1 <4.3.0",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz"
     },
     "hawk": {
       "version": "3.1.3",
       "from": "hawk@>=3.1.3 <3.2.0",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
     },
     "hoek": {
       "version": "2.16.3",
       "from": "hoek@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
     },
     "home-path": {
       "version": "1.0.5",
       "from": "home-path@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/home-path/-/home-path-1.0.5.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/home-path/-/home-path-1.0.5.tgz"
     },
     "hosted-git-info": {
       "version": "2.4.2",
       "from": "hosted-git-info@>=2.1.4 <3.0.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz"
     },
     "http-signature": {
       "version": "1.1.1",
       "from": "http-signature@>=1.1.0 <1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
     },
     "indent-string": {
       "version": "2.1.0",
       "from": "indent-string@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz"
     },
     "inflight": {
       "version": "1.0.6",
       "from": "inflight@>=1.0.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
     },
     "inherits": {
       "version": "2.0.3",
       "from": "inherits@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
     },
     "ini": {
       "version": "1.3.4",
       "from": "ini@>=1.3.0 <1.4.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
     },
     "is-arrayish": {
       "version": "0.2.1",
       "from": "is-arrayish@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
     },
     "is-builtin-module": {
       "version": "1.0.0",
       "from": "is-builtin-module@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
     },
     "is-finite": {
       "version": "1.0.2",
       "from": "is-finite@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
     },
     "is-typedarray": {
       "version": "1.0.0",
       "from": "is-typedarray@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
     },
     "is-utf8": {
       "version": "0.2.1",
       "from": "is-utf8@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
     },
     "isarray": {
       "version": "0.0.1",
       "from": "isarray@0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
     },
     "isstream": {
       "version": "0.1.2",
       "from": "isstream@>=0.1.2 <0.2.0",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
     },
     "jquery": {
       "version": "3.1.0",
       "from": "https://registry.npmjs.org/jquery/-/jquery-3.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.1.0.tgz"
     },
     "jsbn": {
       "version": "0.1.1",
       "from": "jsbn@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "dev": true,
-      "optional": true
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
     },
     "jsdom": {
       "version": "9.4.1",
       "from": "https://registry.npmjs.org/jsdom/-/jsdom-9.4.1.tgz",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.4.1.tgz",
-      "dev": true,
       "dependencies": {
         "abab": {
           "version": "1.0.3",
           "from": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
-          "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz"
         },
         "acorn": {
           "version": "2.7.0",
           "from": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
         },
         "acorn-globals": {
           "version": "1.0.9",
           "from": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
-          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz"
         },
         "array-equal": {
           "version": "1.0.0",
           "from": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz"
         },
         "cssom": {
           "version": "0.3.1",
           "from": "https://registry.npmjs.org/cssom/-/cssom-0.3.1.tgz",
-          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.1.tgz"
         },
         "cssstyle": {
           "version": "0.2.36",
           "from": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.36.tgz",
-          "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.36.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.36.tgz"
         },
         "escodegen": {
           "version": "1.8.0",
           "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.0.tgz",
           "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.0.tgz",
-          "dev": true,
           "dependencies": {
             "esprima": {
               "version": "2.7.2",
               "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
             },
             "estraverse": {
               "version": "1.9.3",
               "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
             },
             "esutils": {
               "version": "2.0.2",
               "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
             },
             "optionator": {
               "version": "0.8.1",
               "from": "https://registry.npmjs.org/optionator/-/optionator-0.8.1.tgz",
               "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.1.tgz",
-              "dev": true,
               "dependencies": {
                 "deep-is": {
                   "version": "0.1.3",
                   "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-                  "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                 },
                 "fast-levenshtein": {
                   "version": "1.1.3",
                   "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.3.tgz",
-                  "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.3.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.3.tgz"
                 },
                 "levn": {
                   "version": "0.3.0",
                   "from": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz"
                 },
                 "prelude-ls": {
                   "version": "1.1.2",
                   "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
                 },
                 "type-check": {
                   "version": "0.3.2",
                   "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-                  "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
                 },
                 "wordwrap": {
                   "version": "1.0.0",
                   "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
                 }
               }
             },
@@ -5668,15 +4808,11 @@
               "version": "0.2.0",
               "from": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-              "dev": true,
-              "optional": true,
               "dependencies": {
                 "amdefine": {
                   "version": "1.0.0",
                   "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-                  "dev": true,
-                  "optional": true
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                 }
               }
             }
@@ -5685,86 +4821,72 @@
         "iconv-lite": {
           "version": "0.4.13",
           "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
         },
         "nwmatcher": {
           "version": "1.3.8",
           "from": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.8.tgz",
-          "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.8.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.8.tgz"
         },
         "parse5": {
           "version": "1.5.1",
           "from": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz"
         },
         "request": {
           "version": "2.73.0",
           "from": "https://registry.npmjs.org/request/-/request-2.73.0.tgz",
           "resolved": "https://registry.npmjs.org/request/-/request-2.73.0.tgz",
-          "dev": true,
           "dependencies": {
             "aws-sign2": {
               "version": "0.6.0",
               "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
             },
             "aws4": {
               "version": "1.4.1",
               "from": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
-              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz"
             },
             "bl": {
               "version": "1.1.2",
               "from": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-              "dev": true,
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.6",
                   "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                  "dev": true,
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
                       "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
                       "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "isarray": {
                       "version": "1.0.0",
                       "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.7",
                       "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
                       "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
                       "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
                 }
@@ -5773,46 +4895,39 @@
             "caseless": {
               "version": "0.11.0",
               "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
             },
             "combined-stream": {
               "version": "1.0.5",
               "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-              "dev": true,
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
                   "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                 }
               }
             },
             "extend": {
               "version": "3.0.0",
               "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
             },
             "forever-agent": {
               "version": "0.6.1",
               "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
             },
             "form-data": {
               "version": "1.0.0-rc4",
               "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
-              "dev": true,
               "dependencies": {
                 "async": {
                   "version": "1.5.2",
                   "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-                  "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
                 }
               }
             },
@@ -5820,37 +4935,31 @@
               "version": "2.0.6",
               "from": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
               "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-              "dev": true,
               "dependencies": {
                 "chalk": {
                   "version": "1.1.3",
                   "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                  "dev": true,
                   "dependencies": {
                     "ansi-styles": {
                       "version": "2.2.1",
                       "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                     },
                     "escape-string-regexp": {
                       "version": "1.0.5",
                       "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                     },
                     "has-ansi": {
                       "version": "2.0.0",
                       "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                      "dev": true,
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
                           "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         }
                       }
                     },
@@ -5858,21 +4967,18 @@
                       "version": "3.0.1",
                       "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                      "dev": true,
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
                           "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         }
                       }
                     },
                     "supports-color": {
                       "version": "2.0.0",
                       "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                     }
                   }
                 },
@@ -5880,13 +4986,11 @@
                   "version": "2.9.0",
                   "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
                       "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     }
                   }
                 },
@@ -5894,39 +4998,33 @@
                   "version": "2.13.1",
                   "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
                   "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
-                  "dev": true,
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
                       "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                     },
                     "generate-object-property": {
                       "version": "1.2.0",
                       "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                      "dev": true,
                       "dependencies": {
                         "is-property": {
                           "version": "1.0.2",
                           "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                         }
                       }
                     },
                     "jsonpointer": {
                       "version": "2.0.0",
                       "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                     },
                     "xtend": {
                       "version": "4.0.1",
                       "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                     }
                   }
                 },
@@ -5934,13 +5032,11 @@
                   "version": "2.0.1",
                   "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                  "dev": true,
                   "dependencies": {
                     "pinkie": {
                       "version": "2.0.4",
                       "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                     }
                   }
                 }
@@ -5950,31 +5046,26 @@
               "version": "3.1.3",
               "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-              "dev": true,
               "dependencies": {
                 "boom": {
                   "version": "2.10.1",
                   "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.5",
                   "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                 },
                 "hoek": {
                   "version": "2.16.3",
                   "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                 },
                 "sntp": {
                   "version": "1.0.9",
                   "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 }
               }
             },
@@ -5982,37 +5073,31 @@
               "version": "1.1.1",
               "from": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-              "dev": true,
               "dependencies": {
                 "assert-plus": {
                   "version": "0.2.0",
                   "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
                 },
                 "jsprim": {
                   "version": "1.3.0",
                   "from": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "extsprintf": {
                       "version": "1.0.2",
                       "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                     },
                     "json-schema": {
                       "version": "0.2.2",
                       "from": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
-                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
                     },
                     "verror": {
                       "version": "1.3.6",
                       "from": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
                     }
                   }
                 },
@@ -6020,59 +5105,46 @@
                   "version": "1.8.3",
                   "from": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.3.tgz",
                   "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.3.tgz",
-                  "dev": true,
                   "dependencies": {
                     "asn1": {
                       "version": "0.2.3",
                       "from": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
                     },
                     "assert-plus": {
                       "version": "1.0.0",
                       "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                     },
                     "dashdash": {
                       "version": "1.14.0",
                       "from": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
-                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz"
                     },
                     "ecc-jsbn": {
                       "version": "0.1.1",
                       "from": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                      "dev": true,
-                      "optional": true
+                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                     },
                     "getpass": {
                       "version": "0.1.6",
                       "from": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz"
                     },
                     "jodid25519": {
                       "version": "1.0.2",
                       "from": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                      "dev": true,
-                      "optional": true
+                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
                     },
                     "jsbn": {
                       "version": "0.1.0",
                       "from": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-                      "dev": true,
-                      "optional": true
+                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                     },
                     "tweetnacl": {
                       "version": "0.13.3",
                       "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
-                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
-                      "dev": true,
-                      "optional": true
+                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
                     }
                   }
                 }
@@ -6081,210 +5153,177 @@
             "is-typedarray": {
               "version": "1.0.0",
               "from": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
             },
             "isstream": {
               "version": "0.1.2",
               "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "json-stringify-safe": {
               "version": "5.0.1",
               "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "mime-types": {
               "version": "2.1.11",
               "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
-              "dev": true,
               "dependencies": {
                 "mime-db": {
                   "version": "1.23.0",
                   "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
                 }
               }
             },
             "node-uuid": {
               "version": "1.4.7",
               "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
             },
             "oauth-sign": {
               "version": "0.8.2",
               "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
             },
             "qs": {
               "version": "6.2.0",
               "from": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
             },
             "stringstream": {
               "version": "0.0.5",
               "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.3",
               "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
             }
           }
         },
         "sax": {
           "version": "1.2.1",
           "from": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz"
         },
         "symbol-tree": {
           "version": "3.1.4",
           "from": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.1.4.tgz",
-          "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.1.4.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.1.4.tgz"
         },
         "tough-cookie": {
           "version": "2.2.2",
           "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
         },
         "webidl-conversions": {
           "version": "3.0.1",
           "from": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz"
         },
         "whatwg-url": {
           "version": "3.0.0",
           "from": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-3.0.0.tgz",
-          "dev": true,
           "dependencies": {
             "tr46": {
               "version": "0.0.3",
               "from": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz"
             }
           }
         },
         "xml-name-validator": {
           "version": "2.0.1",
           "from": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz"
         }
       }
     },
     "json-schema": {
       "version": "0.2.3",
       "from": "json-schema@0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
     },
     "json-stable-stringify": {
       "version": "1.0.1",
       "from": "json-stable-stringify@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
     },
     "json-stringify-safe": {
       "version": "5.0.1",
       "from": "json-stringify-safe@>=5.0.1 <5.1.0",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
     },
     "jsonify": {
       "version": "0.0.0",
       "from": "jsonify@>=0.0.0 <0.1.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
     },
     "jsprim": {
       "version": "1.4.0",
       "from": "jsprim@>=1.2.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-      "dev": true,
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
           "from": "assert-plus@1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
     },
     "load-json-file": {
       "version": "1.1.0",
       "from": "load-json-file@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz"
     },
     "loud-rejection": {
       "version": "1.6.0",
       "from": "loud-rejection@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz"
     },
     "map-obj": {
       "version": "1.0.1",
       "from": "map-obj@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
     },
     "meow": {
       "version": "3.7.0",
       "from": "meow@>=3.1.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz"
     },
     "mime-db": {
       "version": "1.27.0",
       "from": "mime-db@>=1.27.0 <1.28.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
     },
     "mime-types": {
       "version": "2.1.15",
       "from": "mime-types@>=2.1.7 <2.2.0",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz"
     },
     "minimatch": {
       "version": "3.0.4",
       "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
     },
     "minimist": {
       "version": "1.2.0",
       "from": "minimist@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
     },
     "mkdirp": {
       "version": "0.5.1",
       "from": "mkdirp@>=0.5.0 <0.6.0",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "dev": true,
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
           "from": "minimist@0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
         }
       }
     },
@@ -6292,69 +5331,58 @@
       "version": "2.5.3",
       "from": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
-      "dev": true,
       "dependencies": {
         "commander": {
           "version": "2.3.0",
           "from": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
         },
         "debug": {
           "version": "2.2.0",
           "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "dev": true,
           "dependencies": {
             "ms": {
               "version": "0.7.1",
               "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "diff": {
           "version": "1.4.0",
           "from": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz"
         },
         "escape-string-regexp": {
           "version": "1.0.2",
           "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
         },
         "glob": {
           "version": "3.2.11",
           "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-          "dev": true,
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
               "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
               "version": "0.3.0",
               "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-              "dev": true,
               "dependencies": {
                 "lru-cache": {
                   "version": "2.7.3",
                   "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.1",
                   "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
             }
@@ -6363,26 +5391,22 @@
         "growl": {
           "version": "1.9.2",
           "from": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-          "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz"
         },
         "jade": {
           "version": "0.26.3",
           "from": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
           "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
-          "dev": true,
           "dependencies": {
             "commander": {
               "version": "0.6.1",
               "from": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
             },
             "mkdirp": {
               "version": "0.3.0",
               "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
             }
           }
         },
@@ -6390,147 +5414,124 @@
           "version": "0.5.1",
           "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "dev": true,
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
               "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "supports-color": {
           "version": "1.2.0",
           "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz"
         },
         "to-iso-string": {
           "version": "0.0.2",
           "from": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz"
         }
       }
     },
     "ms": {
       "version": "2.0.0",
       "from": "ms@2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
     },
     "mv": {
       "version": "2.1.1",
       "from": "mv@>=2.0.3 <3.0.0",
-      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz"
     },
     "ncp": {
       "version": "2.0.0",
       "from": "ncp@>=2.0.0 <2.1.0",
-      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz"
     },
     "nodemon": {
       "version": "1.9.2",
       "from": "https://registry.npmjs.org/nodemon/-/nodemon-1.9.2.tgz",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.9.2.tgz",
-      "dev": true,
       "dependencies": {
         "chokidar": {
           "version": "1.6.0",
           "from": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.0.tgz",
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.0.tgz",
-          "dev": true,
           "dependencies": {
             "anymatch": {
               "version": "1.3.0",
               "from": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
-              "dev": true,
               "dependencies": {
                 "arrify": {
                   "version": "1.0.1",
                   "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
                 },
                 "micromatch": {
                   "version": "2.3.10",
                   "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.10.tgz",
                   "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.10.tgz",
-                  "dev": true,
                   "dependencies": {
                     "arr-diff": {
                       "version": "2.0.0",
                       "from": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-                      "dev": true,
                       "dependencies": {
                         "arr-flatten": {
                           "version": "1.0.1",
                           "from": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
                         }
                       }
                     },
                     "array-unique": {
                       "version": "0.2.1",
                       "from": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
                     },
                     "braces": {
                       "version": "1.8.5",
                       "from": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
                       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-                      "dev": true,
                       "dependencies": {
                         "expand-range": {
                           "version": "1.8.2",
                           "from": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
                           "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-                          "dev": true,
                           "dependencies": {
                             "fill-range": {
                               "version": "2.2.3",
                               "from": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
                               "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-                              "dev": true,
                               "dependencies": {
                                 "is-number": {
                                   "version": "2.1.0",
                                   "from": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
                                 },
                                 "isobject": {
                                   "version": "2.1.0",
                                   "from": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                                   "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-                                  "dev": true,
                                   "dependencies": {
                                     "isarray": {
                                       "version": "1.0.0",
                                       "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                                      "dev": true
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                                     }
                                   }
                                 },
                                 "randomatic": {
                                   "version": "1.1.5",
                                   "from": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
-                                  "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.5.4",
                                   "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                                 }
                               }
                             }
@@ -6539,14 +5540,12 @@
                         "preserve": {
                           "version": "0.2.0",
                           "from": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-                          "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
                         },
                         "repeat-element": {
                           "version": "1.1.2",
                           "from": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-                          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
                         }
                       }
                     },
@@ -6554,79 +5553,67 @@
                       "version": "0.1.5",
                       "from": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
                       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-                      "dev": true,
                       "dependencies": {
                         "is-posix-bracket": {
                           "version": "0.1.1",
                           "from": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-                          "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
                         }
                       }
                     },
                     "extglob": {
                       "version": "0.3.2",
                       "from": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-                      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
                     },
                     "filename-regex": {
                       "version": "2.0.0",
                       "from": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
                     },
                     "is-extglob": {
                       "version": "1.0.0",
                       "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                     },
                     "kind-of": {
                       "version": "3.0.3",
                       "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz",
-                      "dev": true,
                       "dependencies": {
                         "is-buffer": {
                           "version": "1.1.3",
                           "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
-                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                         }
                       }
                     },
                     "normalize-path": {
                       "version": "2.0.1",
                       "from": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
                     },
                     "object.omit": {
                       "version": "2.0.0",
                       "from": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
-                      "dev": true,
                       "dependencies": {
                         "for-own": {
                           "version": "0.1.4",
                           "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
                           "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
-                          "dev": true,
                           "dependencies": {
                             "for-in": {
                               "version": "0.1.5",
                               "from": "https://registry.npmjs.org/for-in/-/for-in-0.1.5.tgz",
-                              "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.5.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.5.tgz"
                             }
                           }
                         },
                         "is-extendable": {
                           "version": "0.1.1",
                           "from": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-                          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
                         }
                       }
                     },
@@ -6634,19 +5621,16 @@
                       "version": "3.0.4",
                       "from": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-                      "dev": true,
                       "dependencies": {
                         "glob-base": {
                           "version": "0.3.0",
                           "from": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-                          "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
                         },
                         "is-dotfile": {
                           "version": "1.0.2",
                           "from": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
                         }
                       }
                     },
@@ -6654,19 +5638,16 @@
                       "version": "0.4.3",
                       "from": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
                       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-                      "dev": true,
                       "dependencies": {
                         "is-equal-shallow": {
                           "version": "0.1.3",
                           "from": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-                          "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
                         },
                         "is-primitive": {
                           "version": "2.0.0",
                           "from": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
                         }
                       }
                     }
@@ -6677,867 +5658,27 @@
             "async-each": {
               "version": "1.0.0",
               "from": "https://registry.npmjs.org/async-each/-/async-each-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.0.tgz",
-              "dev": true
-            },
-            "fsevents": {
-              "version": "1.0.12",
-              "from": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.12.tgz",
-              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.12.tgz",
-              "dev": true,
-              "optional": true,
-              "dependencies": {
-                "ansi": {
-                  "version": "0.3.1",
-                  "from": "ansi@~0.3.1",
-                  "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
-                  "dev": true
-                },
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "ansi-regex@^2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "dev": true
-                },
-                "ansi-styles": {
-                  "version": "2.2.1",
-                  "from": "ansi-styles@^2.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "are-we-there-yet": {
-                  "version": "1.1.2",
-                  "from": "are-we-there-yet@~1.1.2",
-                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "asn1": {
-                  "version": "0.2.3",
-                  "from": "asn1@>=0.2.3 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "assert-plus": {
-                  "version": "0.2.0",
-                  "from": "assert-plus@^0.2.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                  "dev": true
-                },
-                "async": {
-                  "version": "1.5.2",
-                  "from": "async@^1.5.2",
-                  "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "aws-sign2": {
-                  "version": "0.6.0",
-                  "from": "aws-sign2@~0.6.0",
-                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "aws4": {
-                  "version": "1.3.2",
-                  "from": "aws4@^1.2.1",
-                  "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.3.2.tgz",
-                  "dev": true,
-                  "optional": true,
-                  "dependencies": {
-                    "lru-cache": {
-                      "version": "4.0.1",
-                      "from": "lru-cache@^4.0.0",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
-                      "dev": true,
-                      "optional": true,
-                      "dependencies": {
-                        "pseudomap": {
-                          "version": "1.0.2",
-                          "from": "pseudomap@^1.0.1",
-                          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-                          "dev": true,
-                          "optional": true
-                        },
-                        "yallist": {
-                          "version": "2.0.0",
-                          "from": "yallist@^2.0.0",
-                          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz",
-                          "dev": true,
-                          "optional": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "bl": {
-                  "version": "1.0.3",
-                  "from": "bl@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "block-stream": {
-                  "version": "0.0.8",
-                  "from": "block-stream@*",
-                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz",
-                  "dev": true
-                },
-                "boom": {
-                  "version": "2.10.1",
-                  "from": "boom@2.x.x",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                  "dev": true
-                },
-                "caseless": {
-                  "version": "0.11.0",
-                  "from": "caseless@~0.11.0",
-                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "chalk": {
-                  "version": "1.1.3",
-                  "from": "chalk@^1.1.1",
-                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "combined-stream": {
-                  "version": "1.0.5",
-                  "from": "combined-stream@~1.0.5",
-                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                  "dev": true
-                },
-                "commander": {
-                  "version": "2.9.0",
-                  "from": "commander@^2.9.0",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "core-util-is@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                  "dev": true
-                },
-                "cryptiles": {
-                  "version": "2.0.5",
-                  "from": "cryptiles@2.x.x",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "dashdash": {
-                  "version": "1.13.0",
-                  "from": "dashdash@>=1.10.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.0.tgz",
-                  "dev": true,
-                  "optional": true,
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "1.0.0",
-                      "from": "assert-plus@^1.0.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                      "dev": true,
-                      "optional": true
-                    }
-                  }
-                },
-                "debug": {
-                  "version": "2.2.0",
-                  "from": "debug@~2.2.0",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "deep-extend": {
-                  "version": "0.4.1",
-                  "from": "deep-extend@~0.4.0",
-                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "delayed-stream": {
-                  "version": "1.0.0",
-                  "from": "delayed-stream@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                  "dev": true
-                },
-                "delegates": {
-                  "version": "1.0.0",
-                  "from": "delegates@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "ecc-jsbn": {
-                  "version": "0.1.1",
-                  "from": "ecc-jsbn@>=0.0.1 <1.0.0",
-                  "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.5",
-                  "from": "escape-string-regexp@^1.0.2",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "extend": {
-                  "version": "3.0.0",
-                  "from": "extend@~3.0.0",
-                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "extsprintf": {
-                  "version": "1.0.2",
-                  "from": "extsprintf@1.0.2",
-                  "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                  "dev": true
-                },
-                "forever-agent": {
-                  "version": "0.6.1",
-                  "from": "forever-agent@~0.6.1",
-                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "form-data": {
-                  "version": "1.0.0-rc4",
-                  "from": "form-data@~1.0.0-rc3",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "fstream": {
-                  "version": "1.0.8",
-                  "from": "fstream@^1.0.2",
-                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
-                  "dev": true
-                },
-                "fstream-ignore": {
-                  "version": "1.0.3",
-                  "from": "fstream-ignore@~1.0.3",
-                  "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.3.tgz",
-                  "dev": true,
-                  "optional": true,
-                  "dependencies": {
-                    "minimatch": {
-                      "version": "3.0.0",
-                      "from": "minimatch@^3.0.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                      "dev": true,
-                      "optional": true,
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.3",
-                          "from": "brace-expansion@^1.0.0",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                          "dev": true,
-                          "optional": true,
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.3.0",
-                              "from": "balanced-match@^0.3.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                              "dev": true,
-                              "optional": true
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                              "dev": true,
-                              "optional": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "gauge": {
-                  "version": "1.2.7",
-                  "from": "gauge@~1.2.5",
-                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "generate-function": {
-                  "version": "2.0.0",
-                  "from": "generate-function@^2.0.0",
-                  "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "generate-object-property": {
-                  "version": "1.2.0",
-                  "from": "generate-object-property@^1.1.0",
-                  "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "graceful-fs": {
-                  "version": "4.1.3",
-                  "from": "graceful-fs@^4.1.2",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
-                  "dev": true
-                },
-                "graceful-readlink": {
-                  "version": "1.0.1",
-                  "from": "graceful-readlink@>= 1.0.0",
-                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "har-validator": {
-                  "version": "2.0.6",
-                  "from": "har-validator@~2.0.6",
-                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "has-ansi": {
-                  "version": "2.0.0",
-                  "from": "has-ansi@^2.0.0",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "has-unicode": {
-                  "version": "2.0.0",
-                  "from": "has-unicode@^2.0.0",
-                  "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "hawk": {
-                  "version": "3.1.3",
-                  "from": "hawk@~3.1.0",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "hoek": {
-                  "version": "2.16.3",
-                  "from": "hoek@2.x.x",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                  "dev": true
-                },
-                "http-signature": {
-                  "version": "1.1.1",
-                  "from": "http-signature@~1.1.0",
-                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@*",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "dev": true
-                },
-                "ini": {
-                  "version": "1.3.4",
-                  "from": "ini@~1.3.0",
-                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "is-my-json-valid": {
-                  "version": "2.13.1",
-                  "from": "is-my-json-valid@^2.12.4",
-                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "is-property": {
-                  "version": "1.0.2",
-                  "from": "is-property@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "is-typedarray": {
-                  "version": "1.0.0",
-                  "from": "is-typedarray@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "isarray": {
-                  "version": "1.0.0",
-                  "from": "isarray@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                  "dev": true
-                },
-                "isstream": {
-                  "version": "0.1.2",
-                  "from": "isstream@~0.1.2",
-                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "jodid25519": {
-                  "version": "1.0.2",
-                  "from": "jodid25519@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "jsbn": {
-                  "version": "0.1.0",
-                  "from": "jsbn@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "json-schema": {
-                  "version": "0.2.2",
-                  "from": "json-schema@0.2.2",
-                  "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "json-stringify-safe": {
-                  "version": "5.0.1",
-                  "from": "json-stringify-safe@~5.0.1",
-                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "jsonpointer": {
-                  "version": "2.0.0",
-                  "from": "jsonpointer@2.0.0",
-                  "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "jsprim": {
-                  "version": "1.2.2",
-                  "from": "jsprim@^1.2.2",
-                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "lodash.pad": {
-                  "version": "4.1.0",
-                  "from": "lodash.pad@^4.1.0",
-                  "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.1.0.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "lodash.padend": {
-                  "version": "4.2.0",
-                  "from": "lodash.padend@^4.1.0",
-                  "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.2.0.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "lodash.padstart": {
-                  "version": "4.2.0",
-                  "from": "lodash.padstart@^4.1.0",
-                  "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.2.0.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "lodash.repeat": {
-                  "version": "4.0.0",
-                  "from": "lodash.repeat@^4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.0.0.tgz",
-                  "dev": true
-                },
-                "lodash.tostring": {
-                  "version": "4.1.2",
-                  "from": "lodash.tostring@^4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.2.tgz",
-                  "dev": true
-                },
-                "mime-db": {
-                  "version": "1.22.0",
-                  "from": "mime-db@~1.22.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz",
-                  "dev": true
-                },
-                "mime-types": {
-                  "version": "2.1.10",
-                  "from": "mime-types@~2.1.7",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
-                  "dev": true
-                },
-                "minimist": {
-                  "version": "0.0.8",
-                  "from": "minimist@0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                  "dev": true
-                },
-                "mkdirp": {
-                  "version": "0.5.1",
-                  "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                  "dev": true
-                },
-                "ms": {
-                  "version": "0.7.1",
-                  "from": "ms@0.7.1",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "nan": {
-                  "version": "2.4.0",
-                  "from": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
-                  "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "node-pre-gyp": {
-                  "version": "0.6.25",
-                  "from": "node-pre-gyp@0.6.25",
-                  "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.25.tgz",
-                  "dev": true,
-                  "optional": true,
-                  "dependencies": {
-                    "nopt": {
-                      "version": "3.0.6",
-                      "from": "nopt@~3.0.1",
-                      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-                      "dev": true,
-                      "optional": true,
-                      "dependencies": {
-                        "abbrev": {
-                          "version": "1.0.7",
-                          "from": "abbrev@1",
-                          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
-                          "dev": true,
-                          "optional": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "node-uuid": {
-                  "version": "1.4.7",
-                  "from": "node-uuid@~1.4.7",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "npmlog": {
-                  "version": "2.0.3",
-                  "from": "npmlog@~2.0.0",
-                  "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.3.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "oauth-sign": {
-                  "version": "0.8.1",
-                  "from": "oauth-sign@~0.8.0",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "once": {
-                  "version": "1.3.3",
-                  "from": "once@~1.3.3",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "pinkie": {
-                  "version": "2.0.4",
-                  "from": "pinkie@^2.0.0",
-                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "pinkie-promise": {
-                  "version": "2.0.0",
-                  "from": "pinkie-promise@^2.0.0",
-                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "process-nextick-args": {
-                  "version": "1.0.6",
-                  "from": "process-nextick-args@~1.0.6",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                  "dev": true
-                },
-                "qs": {
-                  "version": "6.0.2",
-                  "from": "qs@~6.0.2",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "rc": {
-                  "version": "1.1.6",
-                  "from": "rc@~1.1.0",
-                  "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
-                  "dev": true,
-                  "optional": true,
-                  "dependencies": {
-                    "minimist": {
-                      "version": "1.2.0",
-                      "from": "minimist@^1.2.0",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                      "dev": true,
-                      "optional": true
-                    }
-                  }
-                },
-                "readable-stream": {
-                  "version": "2.0.6",
-                  "from": "readable-stream@^2.0.0 || ^1.1.13",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                  "dev": true
-                },
-                "request": {
-                  "version": "2.69.0",
-                  "from": "request@2.x",
-                  "resolved": "https://registry.npmjs.org/request/-/request-2.69.0.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "rimraf": {
-                  "version": "2.5.2",
-                  "from": "rimraf@~2.5.0",
-                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
-                  "dev": true,
-                  "dependencies": {
-                    "glob": {
-                      "version": "7.0.3",
-                      "from": "glob@^7.0.0",
-                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
-                      "dev": true,
-                      "dependencies": {
-                        "inflight": {
-                          "version": "1.0.4",
-                          "from": "inflight@^1.0.4",
-                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                          "dev": true,
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.1",
-                              "from": "wrappy@1",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                              "dev": true
-                            }
-                          }
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "inherits@2",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "dev": true
-                        },
-                        "minimatch": {
-                          "version": "3.0.0",
-                          "from": "minimatch@2 || 3",
-                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                          "dev": true,
-                          "dependencies": {
-                            "brace-expansion": {
-                              "version": "1.1.3",
-                              "from": "brace-expansion@^1.0.0",
-                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                              "dev": true,
-                              "dependencies": {
-                                "balanced-match": {
-                                  "version": "0.3.0",
-                                  "from": "balanced-match@^0.3.0",
-                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                                  "dev": true
-                                },
-                                "concat-map": {
-                                  "version": "0.0.1",
-                                  "from": "concat-map@0.0.1",
-                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                                  "dev": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "once": {
-                          "version": "1.3.3",
-                          "from": "once@^1.3.0",
-                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                          "dev": true,
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.1",
-                              "from": "wrappy@1",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                              "dev": true
-                            }
-                          }
-                        },
-                        "path-is-absolute": {
-                          "version": "1.0.0",
-                          "from": "path-is-absolute@^1.0.0",
-                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "semver": {
-                  "version": "5.1.0",
-                  "from": "semver@~5.1.0",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "sntp": {
-                  "version": "1.0.9",
-                  "from": "sntp@1.x.x",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "sshpk": {
-                  "version": "1.7.4",
-                  "from": "sshpk@^1.7.0",
-                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@~0.10.x",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                  "dev": true
-                },
-                "stringstream": {
-                  "version": "0.0.5",
-                  "from": "stringstream@~0.0.4",
-                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "from": "strip-ansi@^3.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "strip-json-comments": {
-                  "version": "1.0.4",
-                  "from": "strip-json-comments@~1.0.4",
-                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "supports-color": {
-                  "version": "2.0.0",
-                  "from": "supports-color@^2.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "tar": {
-                  "version": "2.2.1",
-                  "from": "tar@~2.2.0",
-                  "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-                  "dev": true
-                },
-                "tar-pack": {
-                  "version": "3.1.3",
-                  "from": "tar-pack@~3.1.0",
-                  "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.3.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "tough-cookie": {
-                  "version": "2.2.2",
-                  "from": "tough-cookie@~2.2.0",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "tunnel-agent": {
-                  "version": "0.4.2",
-                  "from": "tunnel-agent@~0.4.1",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "tweetnacl": {
-                  "version": "0.14.3",
-                  "from": "tweetnacl@>=0.13.0 <1.0.0",
-                  "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "uid-number": {
-                  "version": "0.0.6",
-                  "from": "uid-number@~0.0.6",
-                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "from": "util-deprecate@~1.0.1",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                  "dev": true
-                },
-                "verror": {
-                  "version": "1.3.6",
-                  "from": "verror@1.3.6",
-                  "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "wrappy": {
-                  "version": "1.0.1",
-                  "from": "wrappy@1",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                  "dev": true,
-                  "optional": true
-                },
-                "xtend": {
-                  "version": "4.0.1",
-                  "from": "xtend@^4.0.0",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                  "dev": true,
-                  "optional": true
-                }
-              }
+              "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.0.tgz"
             },
             "glob-parent": {
               "version": "2.0.0",
               "from": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
             },
             "inherits": {
               "version": "2.0.1",
               "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "is-binary-path": {
               "version": "1.0.1",
               "from": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-              "dev": true,
               "dependencies": {
                 "binary-extensions": {
                   "version": "1.5.0",
                   "from": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.5.0.tgz",
-                  "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.5.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.5.0.tgz"
                 }
               }
             },
@@ -7545,83 +5686,70 @@
               "version": "2.0.1",
               "from": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-              "dev": true,
               "dependencies": {
                 "is-extglob": {
                   "version": "1.0.0",
                   "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                 }
               }
             },
             "path-is-absolute": {
               "version": "1.0.0",
               "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             },
             "readdirp": {
               "version": "2.1.0",
               "from": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
               "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
-              "dev": true,
               "dependencies": {
                 "graceful-fs": {
                   "version": "4.1.4",
                   "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
                 },
                 "readable-stream": {
                   "version": "2.1.4",
                   "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
-                  "dev": true,
                   "dependencies": {
                     "buffer-shims": {
                       "version": "1.0.0",
                       "from": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
                     },
                     "core-util-is": {
                       "version": "1.0.2",
                       "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "1.0.0",
                       "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.7",
                       "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
                       "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
                       "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
                 },
                 "set-immediate-shim": {
                   "version": "1.0.1",
                   "from": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
                 }
               }
             }
@@ -7631,51 +5759,43 @@
           "version": "2.2.0",
           "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "dev": true,
           "dependencies": {
             "ms": {
               "version": "0.7.1",
               "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "es6-promise": {
           "version": "3.2.1",
           "from": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz"
         },
         "ignore-by-default": {
           "version": "1.0.1",
           "from": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz"
         },
         "lodash.defaults": {
           "version": "3.1.2",
           "from": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz",
           "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz",
-          "dev": true,
           "dependencies": {
             "lodash.assign": {
               "version": "3.2.0",
               "from": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
-              "dev": true,
               "dependencies": {
                 "lodash._baseassign": {
                   "version": "3.2.0",
                   "from": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "lodash._basecopy": {
                       "version": "3.0.1",
                       "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
                     }
                   }
                 },
@@ -7683,19 +5803,16 @@
                   "version": "3.1.1",
                   "from": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
-                  "dev": true,
                   "dependencies": {
                     "lodash._bindcallback": {
                       "version": "3.0.1",
                       "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
                     },
                     "lodash._isiterateecall": {
                       "version": "3.0.9",
                       "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
                     }
                   }
                 },
@@ -7703,25 +5820,21 @@
                   "version": "3.1.2",
                   "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-                  "dev": true,
                   "dependencies": {
                     "lodash._getnative": {
                       "version": "3.9.1",
                       "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                     },
                     "lodash.isarguments": {
                       "version": "3.0.8",
                       "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
                     },
                     "lodash.isarray": {
                       "version": "3.0.4",
                       "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                     }
                   }
                 }
@@ -7730,8 +5843,7 @@
             "lodash.restparam": {
               "version": "3.6.1",
               "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-              "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
             }
           }
         },
@@ -7739,25 +5851,21 @@
           "version": "3.0.2",
           "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
-          "dev": true,
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.5",
               "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz",
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz",
-              "dev": true,
               "dependencies": {
                 "balanced-match": {
                   "version": "0.4.1",
                   "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz"
                 },
                 "concat-map": {
                   "version": "0.0.1",
                   "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                 }
               }
             }
@@ -7767,55 +5875,46 @@
           "version": "1.1.0",
           "from": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
-          "dev": true,
           "dependencies": {
             "event-stream": {
               "version": "3.3.3",
               "from": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.3.tgz",
               "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.3.tgz",
-              "dev": true,
               "dependencies": {
                 "duplexer": {
                   "version": "0.1.1",
                   "from": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
                 },
                 "from": {
                   "version": "0.1.3",
                   "from": "https://registry.npmjs.org/from/-/from-0.1.3.tgz",
-                  "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz"
                 },
                 "map-stream": {
                   "version": "0.1.0",
                   "from": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
                 },
                 "pause-stream": {
                   "version": "0.0.11",
                   "from": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-                  "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
                 },
                 "split": {
                   "version": "0.3.3",
                   "from": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-                  "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz"
                 },
                 "stream-combiner": {
                   "version": "0.0.4",
                   "from": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-                  "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
                 },
                 "through": {
                   "version": "2.3.8",
                   "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
             }
@@ -7825,19 +5924,16 @@
           "version": "1.0.0",
           "from": "https://registry.npmjs.org/touch/-/touch-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/touch/-/touch-1.0.0.tgz",
-          "dev": true,
           "dependencies": {
             "nopt": {
               "version": "1.0.10",
               "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-              "dev": true,
               "dependencies": {
                 "abbrev": {
                   "version": "1.0.9",
                   "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
                 }
               }
             }
@@ -7846,44 +5942,37 @@
         "undefsafe": {
           "version": "0.0.3",
           "from": "https://registry.npmjs.org/undefsafe/-/undefsafe-0.0.3.tgz",
-          "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-0.0.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-0.0.3.tgz"
         },
         "update-notifier": {
           "version": "0.5.0",
           "from": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.5.0.tgz",
           "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.5.0.tgz",
-          "dev": true,
           "dependencies": {
             "chalk": {
               "version": "1.1.3",
               "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "dev": true,
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.2.1",
                   "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.5",
                   "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
                   "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
                       "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
@@ -7891,21 +5980,18 @@
                   "version": "3.0.1",
                   "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "dev": true,
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
                       "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
                   "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
@@ -7913,77 +5999,65 @@
               "version": "1.4.0",
               "from": "https://registry.npmjs.org/configstore/-/configstore-1.4.0.tgz",
               "resolved": "https://registry.npmjs.org/configstore/-/configstore-1.4.0.tgz",
-              "dev": true,
               "dependencies": {
                 "graceful-fs": {
                   "version": "4.1.4",
                   "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
                 },
                 "mkdirp": {
                   "version": "0.5.1",
                   "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                  "dev": true,
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
                       "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     }
                   }
                 },
                 "object-assign": {
                   "version": "4.1.0",
                   "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
                 },
                 "os-tmpdir": {
                   "version": "1.0.1",
                   "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                 },
                 "osenv": {
                   "version": "0.1.3",
                   "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-                  "dev": true,
                   "dependencies": {
                     "os-homedir": {
                       "version": "1.0.1",
                       "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
                     }
                   }
                 },
                 "uuid": {
                   "version": "2.0.2",
                   "from": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz"
                 },
                 "write-file-atomic": {
                   "version": "1.1.4",
                   "from": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz",
                   "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz",
-                  "dev": true,
                   "dependencies": {
                     "imurmurhash": {
                       "version": "0.1.4",
                       "from": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-                      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
                     },
                     "slide": {
                       "version": "1.1.6",
                       "from": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-                      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
                     }
                   }
                 },
@@ -7991,13 +6065,11 @@
                   "version": "2.0.0",
                   "from": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "os-homedir": {
                       "version": "1.0.1",
                       "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
                     }
                   }
                 }
@@ -8006,50 +6078,42 @@
             "is-npm": {
               "version": "1.0.0",
               "from": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz"
             },
             "latest-version": {
               "version": "1.0.1",
               "from": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.1.tgz",
-              "dev": true,
               "dependencies": {
                 "package-json": {
                   "version": "1.2.0",
                   "from": "https://registry.npmjs.org/package-json/-/package-json-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/package-json/-/package-json-1.2.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "got": {
                       "version": "3.3.1",
                       "from": "https://registry.npmjs.org/got/-/got-3.3.1.tgz",
                       "resolved": "https://registry.npmjs.org/got/-/got-3.3.1.tgz",
-                      "dev": true,
                       "dependencies": {
                         "duplexify": {
                           "version": "3.4.5",
                           "from": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.5.tgz",
                           "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.5.tgz",
-                          "dev": true,
                           "dependencies": {
                             "end-of-stream": {
                               "version": "1.0.0",
                               "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
-                              "dev": true,
                               "dependencies": {
                                 "once": {
                                   "version": "1.3.3",
                                   "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                                  "dev": true,
                                   "dependencies": {
                                     "wrappy": {
                                       "version": "1.0.2",
                                       "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                                      "dev": true
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                                     }
                                   }
                                 }
@@ -8058,128 +6122,108 @@
                             "inherits": {
                               "version": "2.0.1",
                               "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             },
                             "readable-stream": {
                               "version": "2.1.4",
                               "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
                               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
-                              "dev": true,
                               "dependencies": {
                                 "buffer-shims": {
                                   "version": "1.0.0",
                                   "from": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
                                 },
                                 "core-util-is": {
                                   "version": "1.0.2",
                                   "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                                 },
                                 "isarray": {
                                   "version": "1.0.0",
                                   "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                                 },
                                 "process-nextick-args": {
                                   "version": "1.0.7",
                                   "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                                 },
                                 "string_decoder": {
                                   "version": "0.10.31",
                                   "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                                 },
                                 "util-deprecate": {
                                   "version": "1.0.2",
                                   "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                                 }
                               }
                             },
                             "stream-shift": {
                               "version": "1.0.0",
                               "from": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz"
                             }
                           }
                         },
                         "infinity-agent": {
                           "version": "2.0.3",
                           "from": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz",
-                          "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz"
                         },
                         "is-redirect": {
                           "version": "1.0.0",
                           "from": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz"
                         },
                         "is-stream": {
                           "version": "1.1.0",
                           "from": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
                         },
                         "lowercase-keys": {
                           "version": "1.0.0",
                           "from": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
                         },
                         "nested-error-stacks": {
                           "version": "1.0.2",
                           "from": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.2.tgz",
-                          "dev": true,
                           "dependencies": {
                             "inherits": {
                               "version": "2.0.1",
                               "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             }
                           }
                         },
                         "object-assign": {
                           "version": "3.0.0",
                           "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
                         },
                         "prepend-http": {
                           "version": "1.0.4",
                           "from": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-                          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz"
                         },
                         "read-all-stream": {
                           "version": "3.1.0",
                           "from": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
-                          "dev": true,
                           "dependencies": {
                             "pinkie-promise": {
                               "version": "2.0.1",
                               "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                              "dev": true,
                               "dependencies": {
                                 "pinkie": {
                                   "version": "2.0.4",
                                   "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                                 }
                               }
                             },
@@ -8187,49 +6231,41 @@
                               "version": "2.1.4",
                               "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
                               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
-                              "dev": true,
                               "dependencies": {
                                 "buffer-shims": {
                                   "version": "1.0.0",
                                   "from": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
                                 },
                                 "core-util-is": {
                                   "version": "1.0.2",
                                   "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                                 },
                                 "inherits": {
                                   "version": "2.0.1",
                                   "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 },
                                 "isarray": {
                                   "version": "1.0.0",
                                   "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                                 },
                                 "process-nextick-args": {
                                   "version": "1.0.7",
                                   "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                                 },
                                 "string_decoder": {
                                   "version": "0.10.31",
                                   "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                                 },
                                 "util-deprecate": {
                                   "version": "1.0.2",
                                   "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                                 }
                               }
                             }
@@ -8238,8 +6274,7 @@
                         "timed-out": {
                           "version": "2.0.0",
                           "from": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
                         }
                       }
                     },
@@ -8247,37 +6282,31 @@
                       "version": "3.1.0",
                       "from": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-                      "dev": true,
                       "dependencies": {
                         "rc": {
                           "version": "1.1.6",
                           "from": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
                           "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
-                          "dev": true,
                           "dependencies": {
                             "deep-extend": {
                               "version": "0.4.1",
                               "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-                              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
                             },
                             "ini": {
                               "version": "1.3.4",
                               "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-                              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                             },
                             "minimist": {
                               "version": "1.2.0",
                               "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                             },
                             "strip-json-comments": {
                               "version": "1.0.4",
                               "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-                              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
                             }
                           }
                         }
@@ -8291,19 +6320,16 @@
               "version": "1.1.3",
               "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
               "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-              "dev": true,
               "dependencies": {
                 "is-finite": {
                   "version": "1.0.1",
                   "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                  "dev": true,
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
                       "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                     }
                   }
                 }
@@ -8313,13 +6339,11 @@
               "version": "2.1.0",
               "from": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
               "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-              "dev": true,
               "dependencies": {
                 "semver": {
                   "version": "5.2.0",
                   "from": "https://registry.npmjs.org/semver/-/semver-5.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.2.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.2.0.tgz"
                 }
               }
             },
@@ -8327,19 +6351,16 @@
               "version": "1.0.1",
               "from": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
-              "dev": true,
               "dependencies": {
                 "strip-ansi": {
                   "version": "3.0.1",
                   "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "dev": true,
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
                       "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 }
@@ -8352,188 +6373,157 @@
     "normalize-package-data": {
       "version": "2.3.8",
       "from": "normalize-package-data@>=2.3.4 <3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz"
     },
     "nugget": {
       "version": "1.6.2",
       "from": "nugget@>=1.5.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/nugget/-/nugget-1.6.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/nugget/-/nugget-1.6.2.tgz"
     },
     "number-is-nan": {
       "version": "1.0.1",
       "from": "number-is-nan@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
     },
     "oauth-sign": {
       "version": "0.8.2",
       "from": "oauth-sign@>=0.8.1 <0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
     },
     "object-assign": {
       "version": "4.1.1",
       "from": "object-assign@>=4.0.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
     },
     "object-keys": {
       "version": "0.4.0",
       "from": "object-keys@>=0.4.0 <0.5.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
     },
     "once": {
       "version": "1.4.0",
       "from": "once@>=1.3.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
     },
     "parse-json": {
       "version": "2.2.0",
       "from": "parse-json@>=2.2.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"
     },
     "path-exists": {
       "version": "1.0.0",
       "from": "path-exists@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "from": "path-is-absolute@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
     },
     "path-type": {
       "version": "1.1.0",
       "from": "path-type@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
     },
     "pend": {
       "version": "1.2.0",
       "from": "pend@>=1.2.0 <1.3.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
     },
     "performance-now": {
       "version": "0.2.0",
       "from": "performance-now@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz"
     },
     "pify": {
       "version": "2.3.0",
       "from": "pify@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
     },
     "pinkie": {
       "version": "2.0.4",
       "from": "pinkie@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "from": "pinkie-promise@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
     },
     "pretty-bytes": {
       "version": "1.0.4",
       "from": "pretty-bytes@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz"
     },
     "process-nextick-args": {
       "version": "1.0.7",
       "from": "process-nextick-args@>=1.0.6 <1.1.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
     },
     "progress-stream": {
       "version": "1.2.0",
       "from": "progress-stream@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-1.2.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-1.2.0.tgz"
     },
     "punycode": {
       "version": "1.4.1",
       "from": "punycode@>=1.4.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
     },
     "qs": {
       "version": "6.4.0",
       "from": "qs@>=6.4.0 <6.5.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
     },
     "rc": {
       "version": "1.2.1",
       "from": "rc@>=1.1.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz"
     },
     "read-pkg": {
       "version": "1.1.0",
       "from": "read-pkg@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
     },
     "read-pkg-up": {
       "version": "1.0.1",
       "from": "read-pkg-up@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
     },
     "readable-stream": {
       "version": "1.1.14",
       "from": "readable-stream@>=1.1.9 <1.2.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
     },
     "redent": {
       "version": "1.0.0",
       "from": "redent@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz"
     },
     "repeating": {
       "version": "2.0.1",
       "from": "repeating@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
     },
     "request": {
       "version": "2.81.0",
       "from": "request@>=2.45.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz"
     },
     "rimraf": {
       "version": "2.4.5",
       "from": "rimraf@>=2.4.0 <2.5.0",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz"
     },
     "safe-buffer": {
       "version": "5.1.0",
       "from": "safe-buffer@>=5.0.1 <6.0.0",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz"
     },
     "semver": {
       "version": "5.3.0",
       "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
     },
     "sequelize": {
       "version": "3.30.2",
@@ -10384,50 +8374,42 @@
     "signal-exit": {
       "version": "3.0.2",
       "from": "signal-exit@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
     },
     "single-line-log": {
       "version": "0.4.1",
       "from": "single-line-log@>=0.4.1 <0.5.0",
-      "resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-0.4.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-0.4.1.tgz"
     },
     "sinon": {
       "version": "1.17.4",
       "from": "https://registry.npmjs.org/sinon/-/sinon-1.17.4.tgz",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.4.tgz",
-      "dev": true,
       "dependencies": {
         "formatio": {
           "version": "1.1.1",
           "from": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz"
         },
         "lolex": {
           "version": "1.3.2",
           "from": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
-          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz"
         },
         "samsam": {
           "version": "1.1.2",
           "from": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz"
         },
         "util": {
           "version": "0.10.3",
           "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-          "dev": true,
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
               "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         }
@@ -10436,32 +8418,32 @@
     "sntp": {
       "version": "1.0.9",
       "from": "sntp@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
     },
     "spdx-correct": {
       "version": "1.0.2",
       "from": "spdx-correct@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
     },
     "spdx-expression-parse": {
       "version": "1.0.4",
       "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
     },
     "spdx-license-ids": {
       "version": "1.2.2",
       "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
     },
     "speedometer": {
       "version": "0.1.4",
       "from": "speedometer@>=0.1.2 <0.2.0",
-      "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-0.1.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-0.1.4.tgz"
+    },
+    "split.js": {
+      "version": "1.3.5",
+      "from": "split.js@latest",
+      "resolved": "https://registry.npmjs.org/split.js/-/split.js-1.3.5.tgz"
     },
     "sqlite3": {
       "version": "3.1.8",
@@ -10921,8 +8903,7 @@
                         "bcrypt-pbkdf": {
                           "version": "1.0.0",
                           "from": "bcrypt-pbkdf@^1.0.0",
-                          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
-                          "optional": true
+                          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz"
                         },
                         "dashdash": {
                           "version": "1.14.0",
@@ -10932,8 +8913,7 @@
                         "ecc-jsbn": {
                           "version": "0.1.1",
                           "from": "ecc-jsbn@~0.1.1",
-                          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                          "optional": true
+                          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                         },
                         "getpass": {
                           "version": "0.1.6",
@@ -10943,20 +8923,17 @@
                         "jodid25519": {
                           "version": "1.0.2",
                           "from": "jodid25519@^1.0.0",
-                          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                          "optional": true
+                          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
                         },
                         "jsbn": {
                           "version": "0.1.0",
                           "from": "jsbn@~0.1.0",
-                          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-                          "optional": true
+                          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                         },
                         "tweetnacl": {
                           "version": "0.14.3",
                           "from": "tweetnacl@~0.14.0",
-                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
-                          "optional": true
+                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
                         }
                       }
                     }
@@ -11278,130 +9255,108 @@
       "version": "1.13.1",
       "from": "sshpk@>=1.7.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-      "dev": true,
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
           "from": "assert-plus@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
     },
     "string_decoder": {
       "version": "0.10.31",
       "from": "string_decoder@>=0.10.0 <0.11.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
     },
     "stringstream": {
       "version": "0.0.5",
       "from": "stringstream@>=0.0.4 <0.1.0",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
     },
     "strip-bom": {
       "version": "2.0.0",
       "from": "strip-bom@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
     },
     "strip-indent": {
       "version": "1.0.1",
       "from": "strip-indent@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
     },
     "strip-json-comments": {
       "version": "2.0.1",
       "from": "strip-json-comments@>=2.0.1 <2.1.0",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
     },
     "throttleit": {
       "version": "0.0.2",
       "from": "throttleit@0.0.2",
-      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
     },
     "through2": {
       "version": "0.2.3",
       "from": "through2@>=0.2.3 <0.3.0",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz"
     },
     "tough-cookie": {
       "version": "2.3.2",
       "from": "tough-cookie@>=2.3.0 <2.4.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz"
     },
     "trim-newlines": {
       "version": "1.0.0",
       "from": "trim-newlines@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
     },
     "tunnel-agent": {
       "version": "0.6.0",
       "from": "tunnel-agent@>=0.6.0 <0.7.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
     },
     "tweetnacl": {
       "version": "0.14.5",
       "from": "tweetnacl@>=0.14.0 <0.15.0",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "dev": true,
-      "optional": true
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
     },
     "typedarray": {
       "version": "0.0.6",
       "from": "typedarray@>=0.0.6 <0.0.7",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
     },
     "util-deprecate": {
       "version": "1.0.2",
       "from": "util-deprecate@>=1.0.1 <1.1.0",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
     },
     "uuid": {
       "version": "3.0.1",
       "from": "uuid@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
       "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
     },
     "verror": {
       "version": "1.3.6",
       "from": "verror@1.3.6",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
     },
     "wrappy": {
       "version": "1.0.2",
       "from": "wrappy@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
     },
     "xtend": {
       "version": "2.1.2",
       "from": "xtend@>=2.1.1 <2.2.0",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz"
     },
     "yauzl": {
       "version": "2.4.1",
       "from": "yauzl@2.4.1",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "sequelize": "^3.30.2",
     "sequelize-cli": "^2.5.1",
+    "split.js": "1.3.5",
     "sqlite3": "^3.1.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   "dependencies": {
     "sequelize": "^3.30.2",
     "sequelize-cli": "^2.5.1",
-    "split.js": "1.3.5",
     "sqlite3": "^3.1.8"
   }
 }


### PR DESCRIPTION
* The user can now resize the Tree and Table/Node views.
* Resize settings are captured and saved as JSON in `localStorage` during a browser session.
* The Component Summary view is displayed full-width by assigning a separate div-width setting.
* Navigating back to the Tree and Table/Node views retrieves any saved settings from `localStorage`.
* Any saved settings are cleared when AboutCode Manager is closed.