### PR TITLE
On load select root node #152

### DIFF
--- a/assets/js/renderer.js
+++ b/assets/js/renderer.js
@@ -87,6 +87,11 @@ $(document).ready(function () {
                 data.node,
                 'fa fa-folder fa_custom');
         })
+        // Select the root node when the tree is refreshed
+        .on('refresh.jstree', function (evt, data) {
+            let rootNode = jstree.jstree('get_node', '#').children;
+            jstree.jstree('select_node', rootNode);
+        })
         // Get the node id when selected
         .on('select_node.jstree', function (evt, data) {
             let barChartValue = chartAttributesSelect.val();


### PR DESCRIPTION
  * The incoming ScanCode JSON file has no root node, so we create a
    root node and then convert the JSON file to a SQLite3 DB, setting
    the root node's `parent` property to `#`.
  * In the `refresh.jstree` callback, we then look for the node whose
    parent is `#` and set it as selected.  Doing so also displays the
    root node's data in the Chart Summary and Node views.

Signed-off-by: John M. Horan <johnmhoran@gmail.com>