### PR TITLE
Remove default jstree animation #188

### DIFF
--- a/assets/js/renderer.js
+++ b/assets/js/renderer.js
@@ -51,7 +51,8 @@ $(document).ready(function () {
                         .then((children) => {
                             callback.call(this, children)
                         });
-                }
+                },
+                "animation": false
             },
             "types": {
                 "directory": {


### PR DESCRIPTION
* Remove default animation for directory tree when expanding and
  collapsing directories

Signed-off-by: Jillian Daguil <jdaguil@nexb.com>