### PR TITLE
Add warning re unsaved Component edits #127

### DIFF
--- a/assets/app/js/componentDialog.js
+++ b/assets/app/js/componentDialog.js
@@ -47,17 +47,6 @@ class ComponentDialog {
         // Link each close button's click event to a method that checks for unsaved edits.
         this.exitButton.click(() => this._closeComponent());
         this.closeButton.click(() => this._closeComponent());
-
-        // Define attributes that will be modified as necessary in _showDialog() to represent any previously-saved values.
-        this.statusOriginal = "";
-        this.nameOriginal = "";
-        this.versionOriginal = "";
-        this.licenseOriginal = "";
-        this.ownerOriginal = "";
-        this.copyrightOriginal = "";
-        this.languageOriginal = "";
-        this.homepageOriginal = "";
-        this.notesOriginal = "";
     }
 
     database(aboutCodeDB) {
@@ -175,32 +164,17 @@ class ComponentDialog {
         this.dialog.modal({ backdrop: "static", keyboard: false });
 
         // Retrieve any previously-saved values -- use below in _closeComponent() to compare with any new edits before closing the dialog.
-        this.statusOriginal = this.status.val();
-        this.nameOriginal = this.name.val();
-        this.versionOriginal = this.version.val();
-        this.licenseOriginal = this.license.val();
-        this.ownerOriginal = this.owner.val();
-        this.copyrightOriginal = this.copyright.val();
-        this.languageOriginal = this.language.val();
-        this.homepageOriginal = this.homepage.val();
-        this.notesOriginal = this.notes.val();
+        this.initialSerialization = this.dialog.find("form").serialize();
 
         this.dialog.modal('show');
     }
 
     // Check whether the user has made any new edits.
     _closeComponent() {
-        if (($("#component-status").val() != this.statusOriginal) ||
-            ($("#component-name").val() != this.nameOriginal) ||
-            ($("#component-version").val() != this.versionOriginal) ||
-            // The next 4 compare the arrays, e.g., the array of selected licenses.
-            ($($("#component-license").val()).not(this.licenseOriginal).length != 0 || $(this.licenseOriginal).not($("#component-license").val()).length != 0) ||
-            ($($("#component-owner").val()).not(this.ownerOriginal).length != 0 || $(this.ownerOriginal).not($("#component-owner").val()).length != 0) ||
-            ($($("#component-copyright").val()).not(this.copyrightOriginal).length != 0 || $(this.copyrightOriginal).not($("#component-copyright").val()).length != 0) ||
-            ($($("#component-language").val()).not(this.languageOriginal).length != 0 || $(this.languageOriginal).not($("#component-language").val()).length != 0) ||
-            ($("#component-homepage-url").val() != this.homepageOriginal) ||
-            ($("#component-notes").val() != this.notesOriginal)
-            ) {
+        // Retrieve the current form values, i.e., including edits not yet saved.
+        this.currentSerialization = this.dialog.find("form").serialize();
+
+        if (this.initialSerialization !== this.currentSerialization) {
             if(!confirm('Any edits you\'ve made will be lost if you close without saving.  \n\nClick "OK" if you don\'t want to save your edits.')) {
                 // This closes the alert and leaves the modal open if "Cancel" is clicked.
                 return false;

--- a/assets/app/js/componentDialog.js
+++ b/assets/app/js/componentDialog.js
@@ -34,11 +34,30 @@ class ComponentDialog {
         this.saveButton = this.dialog.find("button#component-save");
         this.deleteButton = this.dialog.find("button#component-delete");
 
+        // Define the buttons that can be used to close the dialog.
+        this.exitButton = this.dialog.find("button#component-exit")
+        this.closeButton = this.dialog.find("button#component-close")
+
         // Make node view modal box draggable
         this.dialog.draggable({ handle: ".modal-header" });
         this.handlers = {};
         this.saveButton.click(() => this._saveComponent());
         this.deleteButton.click(() => this._deleteComponent());
+
+        // Link each close button's click event to a method that checks for unsaved edits.
+        this.exitButton.click(() => this._closeComponent());
+        this.closeButton.click(() => this._closeComponent());
+
+        // Define attributes that will be modified as necessary in _showDialog() to represent any previously-saved values.
+        this.statusOriginal = "";
+        this.nameOriginal = "";
+        this.versionOriginal = "";
+        this.licenseOriginal = "";
+        this.ownerOriginal = "";
+        this.copyrightOriginal = "";
+        this.languageOriginal = "";
+        this.homepageOriginal = "";
+        this.notesOriginal = "";
     }
 
     database(aboutCodeDB) {
@@ -151,7 +170,42 @@ class ComponentDialog {
         $('select').trigger('change.select2');
 
         this.title.text(data.id);
+
+        // Disable the ability to close the dialog by clicking outside the dialog or pressing the escape key.
+        this.dialog.modal({ backdrop: "static", keyboard: false });
+
+        // Retrieve any previously-saved values -- use below in _closeComponent() to compare with any new edits before closing the dialog.
+        this.statusOriginal = this.status.val();
+        this.nameOriginal = this.name.val();
+        this.versionOriginal = this.version.val();
+        this.licenseOriginal = this.license.val();
+        this.ownerOriginal = this.owner.val();
+        this.copyrightOriginal = this.copyright.val();
+        this.languageOriginal = this.language.val();
+        this.homepageOriginal = this.homepage.val();
+        this.notesOriginal = this.notes.val();
+
         this.dialog.modal('show');
+    }
+
+    // Check whether the user has made any new edits.
+    _closeComponent() {
+        if (($("#component-status").val() != this.statusOriginal) ||
+            ($("#component-name").val() != this.nameOriginal) ||
+            ($("#component-version").val() != this.versionOriginal) ||
+            // The next 4 compare the arrays, e.g., the array of selected licenses.
+            ($($("#component-license").val()).not(this.licenseOriginal).length != 0 || $(this.licenseOriginal).not($("#component-license").val()).length != 0) ||
+            ($($("#component-owner").val()).not(this.ownerOriginal).length != 0 || $(this.ownerOriginal).not($("#component-owner").val()).length != 0) ||
+            ($($("#component-copyright").val()).not(this.copyrightOriginal).length != 0 || $(this.copyrightOriginal).not($("#component-copyright").val()).length != 0) ||
+            ($($("#component-language").val()).not(this.languageOriginal).length != 0 || $(this.languageOriginal).not($("#component-language").val()).length != 0) ||
+            ($("#component-homepage-url").val() != this.homepageOriginal) ||
+            ($("#component-notes").val() != this.notesOriginal)
+            ) {
+            if(!confirm('Any edits you\'ve made will be lost if you close without saving.  \n\nClick "OK" if you don\'t want to save your edits.')) {
+                // This closes the alert and leaves the modal open if "Cancel" is clicked.
+                return false;
+            }
+        }
     }
 
     _saveComponent() {

--- a/assets/app/js/componentDialog.js
+++ b/assets/app/js/componentDialog.js
@@ -160,10 +160,12 @@ class ComponentDialog {
 
         this.title.text(data.id);
 
-        // Disable the ability to close the dialog by clicking outside the dialog or pressing the escape key.
+        // Disable the ability to close the dialog by clicking outside
+        // the dialog or pressing the escape key.
         this.dialog.modal({ backdrop: "static", keyboard: false });
 
-        // Retrieve any previously-saved values -- use below in _closeComponent() to compare with any new edits before closing the dialog.
+        // Retrieve any previously-saved values -- use below in _closeComponent()
+        // to compare with any new edits before closing the dialog.
         this.initialSerialization = this.dialog.find("form").serialize();
 
         this.dialog.modal('show');
@@ -175,10 +177,7 @@ class ComponentDialog {
         this.currentSerialization = this.dialog.find("form").serialize();
 
         if (this.initialSerialization !== this.currentSerialization) {
-            if(!confirm('Any edits you\'ve made will be lost if you close without saving.  \n\nClick "OK" if you don\'t want to save your edits.')) {
-                // This closes the alert and leaves the modal open if "Cancel" is clicked.
-                return false;
-            }
+            return confirm('Your new changes haven\'t been saved.  \n\nAre you sure you want to exit without saving?')
         }
     }
 

--- a/index.html
+++ b/index.html
@@ -268,7 +268,7 @@
                     <form>
                         <fieldset class="form-group">
                             <label for="component-status">Status</label>
-                            <select class="form-control status" id="component-status" type="text">
+                            <select class="form-control status" id="component-status" name="component-status" type="text">
                                 <option value="Analyzed">Analyzed</option>
                                 <option value="Attention">Needs Attention</option>
                                 <option value="Original">Original Code</option>
@@ -277,35 +277,35 @@
                         </fieldset>
                         <fieldset class="form-group">
                             <label for="component-name">Component</label>
-                            <input type="text" class="form-control" id="component-name" placeholder="Enter component">
+                            <input type="text" class="form-control" id="component-name" name="component-name" placeholder="Enter component">
                         </fieldset>
                         <fieldset class="form-group">
                             <label for="component-version">Version</label>
-                            <input type="text" class="form-control" id="component-version" placeholder="Enter version">
+                            <input type="text" class="form-control" id="component-version" name="component-version" placeholder="Enter version">
                         </fieldset>
                         <fieldset class="form-group">
                             <label for="component-license">License</label>
-                            <select data-hide-on-select="true" class="form-control " id="component-license" type="text"></select>
+                            <select data-hide-on-select="true" class="form-control " id="component-license" name="component-license" type="text"></select>
                         </fieldset>
                         <fieldset class="form-group">
                             <label for="component-owner">Owner</label>
-                            <select data-hide-on-select="true" class="form-control" id="component-owner" type="text"></select>
+                            <select data-hide-on-select="true" class="form-control" id="component-owner" name="component-owner" type="text"></select>
                         </fieldset>
                         <fieldset class="form-group">
                             <label for="component-copyright">Copyright</label>
-                            <select data-hide-on-select="true" class="form-control" id="component-copyright" type="text"></select>
+                            <select data-hide-on-select="true" class="form-control" id="component-copyright" name="component-copyright" type="text"></select>
                         </fieldset>
                          <fieldset class="form-group">
                             <label for="component-language">Programming Language</label>
-                            <select data-hide-on-select="true" class="form-control" id="component-language" type="text"></select>
+                            <select data-hide-on-select="true" class="form-control" id="component-language" name="component-language" type="text"></select>
                         </fieldset>
                          <fieldset class="form-group">
                             <label for="component-homepage-url">Homepage URL</label>
-                            <select data-hide-on-select="true" class="form-control" id="component-homepage-url" type="text"></select>
+                            <select data-hide-on-select="true" class="form-control" id="component-homepage-url" name="component-homepage-url" type="text"></select>
                         </fieldset>
                         <fieldset class="form-group">
                             <label for="component-notes">Notes</label>
-                            <textarea class="form-control" id="component-notes" rows="3"></textarea>
+                            <textarea class="form-control" id="component-notes" name="component-notes" rows="3"></textarea>
                         </fieldset>
                     </form>
                 </div>

--- a/index.html
+++ b/index.html
@@ -261,7 +261,7 @@
         <div class="modal-dialog" role="document">
             <div class="modal-content">
                 <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <button type="button" class="close" data-dismiss="modal" id="component-exit" aria-label="Close"><span aria-hidden="true">&times;</span></button>
                     <h3 class="modal-title">Modal title</h3>
                 </div>
                 <div class="modal-body">
@@ -310,7 +310,7 @@
                     </form>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                    <button type="button" class="btn btn-default" data-dismiss="modal" id="component-close">Close</button>
                     <button type="button" class="btn btn-danger" data-dismiss="modal" id="component-delete">Delete Component</button>
                     <button type="button" class="btn btn-primary" id="component-save">Save changes</button>
                 </div>


### PR DESCRIPTION
  * Connect the two close buttons (`Close` and `X`) to a new class method, `_closeComponent()`.
  * Define attributes for the form's inputs etc. and populate them with any previously-saved values.
  * Disable the ability to close the dialog by clicking outside the dialog or pressing the escape key.
  * `_closeComponent()` tests whether any of the previously-saved values has been changed without saving.

Signed-off-by: John M. Horan <johnmhoran@gmail.com>