### PR TITLE
Check if jsTree node is a file or directory #221

### DIFF
--- a/assets/app/js/renderer.js
+++ b/assets/app/js/renderer.js
@@ -78,7 +78,9 @@ $(document).ready(function () {
         .on("node-selected", node => {
             // Set the search value for the first column (path) equal to the
             // Selected jstree path and redraw the table
-            cluesTable.columns(0).search(node.id + "/").draw();
+            const searchTerm = node.id + (node.type === "file" ? "" : "/");
+
+            cluesTable.columns(0).search(searchTerm).draw();
             nodeView.setRoot(node.id);
             barChart.draw();
         });


### PR DESCRIPTION
When working on #211 a bug was introduced. If a file is selected in the jsTree, the clue results will not show in the table view. This is fixed by checking if the node is a file or directory when a node is selected.

