### PR TITLE
Bump sqlite3 version

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9926,16 +9926,16 @@
       "dev": true
     },
     "sqlite3": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-3.1.10.tgz",
-      "integrity": "sha512-TqyKbHzk96Jc9AaZjQk/Un74rFX3iBv4K3cH4f+rgOkMnoGSQZ2AXDwSFTkBa+yxNDKALLwLW+LBHmT+PhKpFw==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-3.1.13.tgz",
+      "integrity": "sha512-JxXKPJnkZ6NuHRojq+g2WXWBt3M1G9sjZaYiHEWSTGijDM3cwju/0T2XbWqMXFmPqDgw+iB7zKQvnns4bvzXlw==",
       "requires": {
         "nan": "2.7.0",
-        "node-pre-gyp": "0.6.37"
+        "node-pre-gyp": "0.6.38"
       },
       "dependencies": {
         "abbrev": {
-          "version": "1.1.0",
+          "version": "1.1.1",
           "bundled": true
         },
         "ajv": {
@@ -9951,7 +9951,7 @@
           "bundled": true
         },
         "aproba": {
-          "version": "1.1.2",
+          "version": "1.2.0",
           "bundled": true
         },
         "are-we-there-yet": {
@@ -10068,30 +10068,14 @@
           }
         },
         "debug": {
-          "version": "2.6.8",
+          "version": "2.6.9",
           "bundled": true,
           "requires": {
             "ms": "2.0.0"
           }
         },
-        "deep-equal": {
-          "version": "1.0.1",
-          "bundled": true
-        },
         "deep-extend": {
           "version": "0.4.2",
-          "bundled": true
-        },
-        "define-properties": {
-          "version": "1.1.2",
-          "bundled": true,
-          "requires": {
-            "foreach": "2.0.5",
-            "object-keys": "1.0.11"
-          }
-        },
-        "defined": {
-          "version": "1.0.0",
           "bundled": true
         },
         "delayed-stream": {
@@ -10110,43 +10094,12 @@
             "jsbn": "0.1.1"
           }
         },
-        "es-abstract": {
-          "version": "1.8.2",
-          "bundled": true,
-          "requires": {
-            "es-to-primitive": "1.1.1",
-            "function-bind": "1.1.1",
-            "has": "1.0.1",
-            "is-callable": "1.1.3",
-            "is-regex": "1.0.4"
-          }
-        },
-        "es-to-primitive": {
-          "version": "1.1.1",
-          "bundled": true,
-          "requires": {
-            "is-callable": "1.1.3",
-            "is-date-object": "1.0.1",
-            "is-symbol": "1.0.1"
-          }
-        },
         "extend": {
           "version": "3.0.1",
           "bundled": true
         },
         "extsprintf": {
           "version": "1.3.0",
-          "bundled": true
-        },
-        "for-each": {
-          "version": "0.3.2",
-          "bundled": true,
-          "requires": {
-            "is-function": "1.0.1"
-          }
-        },
-        "foreach": {
-          "version": "2.0.5",
           "bundled": true
         },
         "forever-agent": {
@@ -10173,7 +10126,7 @@
             "graceful-fs": "4.1.11",
             "inherits": "2.0.3",
             "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
+            "rimraf": "2.6.2"
           }
         },
         "fstream-ignore": {
@@ -10185,15 +10138,11 @@
             "minimatch": "3.0.4"
           }
         },
-        "function-bind": {
-          "version": "1.1.1",
-          "bundled": true
-        },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
           "requires": {
-            "aproba": "1.1.2",
+            "aproba": "1.2.0",
             "console-control-strings": "1.1.0",
             "has-unicode": "2.0.1",
             "object-assign": "4.1.1",
@@ -10244,13 +10193,6 @@
             "har-schema": "1.0.5"
           }
         },
-        "has": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "function-bind": "1.1.1"
-          }
-        },
         "has-unicode": {
           "version": "2.0.1",
           "bundled": true
@@ -10294,35 +10236,12 @@
           "version": "1.3.4",
           "bundled": true
         },
-        "is-callable": {
-          "version": "1.1.3",
-          "bundled": true
-        },
-        "is-date-object": {
-          "version": "1.0.1",
-          "bundled": true
-        },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
           "requires": {
             "number-is-nan": "1.0.1"
           }
-        },
-        "is-function": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "is-regex": {
-          "version": "1.0.4",
-          "bundled": true,
-          "requires": {
-            "has": "1.0.1"
-          }
-        },
-        "is-symbol": {
-          "version": "1.0.1",
-          "bundled": true
         },
         "is-typedarray": {
           "version": "1.0.0",
@@ -10410,17 +10329,17 @@
           "bundled": true
         },
         "node-pre-gyp": {
-          "version": "0.6.37",
+          "version": "0.6.38",
           "bundled": true,
           "requires": {
+            "hawk": "3.1.3",
             "mkdirp": "0.5.1",
             "nopt": "4.0.1",
             "npmlog": "4.1.2",
             "rc": "1.2.1",
             "request": "2.81.0",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "semver": "5.4.1",
-            "tape": "4.8.0",
             "tar": "2.2.1",
             "tar-pack": "3.4.0"
           }
@@ -10429,7 +10348,7 @@
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "abbrev": "1.1.0",
+            "abbrev": "1.1.1",
             "osenv": "0.1.4"
           }
         },
@@ -10453,14 +10372,6 @@
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true
-        },
-        "object-inspect": {
-          "version": "1.3.0",
-          "bundled": true
-        },
-        "object-keys": {
-          "version": "1.0.11",
           "bundled": true
         },
         "once": {
@@ -10488,10 +10399,6 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true
-        },
-        "path-parse": {
-          "version": "1.0.5",
           "bundled": true
         },
         "performance-now": {
@@ -10562,27 +10469,13 @@
             "qs": "6.4.0",
             "safe-buffer": "5.1.1",
             "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
+            "tough-cookie": "2.3.3",
             "tunnel-agent": "0.6.0",
             "uuid": "3.1.0"
           }
         },
-        "resolve": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "path-parse": "1.0.5"
-          }
-        },
-        "resumer": {
-          "version": "0.0.0",
-          "bundled": true,
-          "requires": {
-            "through": "2.3.8"
-          }
-        },
         "rimraf": {
-          "version": "2.6.1",
+          "version": "2.6.2",
           "bundled": true,
           "requires": {
             "glob": "7.1.2"
@@ -10640,15 +10533,6 @@
             "strip-ansi": "3.0.1"
           }
         },
-        "string.prototype.trim": {
-          "version": "1.1.2",
-          "bundled": true,
-          "requires": {
-            "define-properties": "1.1.2",
-            "es-abstract": "1.8.2",
-            "function-bind": "1.1.1"
-          }
-        },
         "string_decoder": {
           "version": "1.0.3",
           "bundled": true,
@@ -10671,31 +10555,6 @@
           "version": "2.0.1",
           "bundled": true
         },
-        "tape": {
-          "version": "4.8.0",
-          "bundled": true,
-          "requires": {
-            "deep-equal": "1.0.1",
-            "defined": "1.0.0",
-            "for-each": "0.3.2",
-            "function-bind": "1.1.1",
-            "glob": "7.1.2",
-            "has": "1.0.1",
-            "inherits": "2.0.3",
-            "minimist": "1.2.0",
-            "object-inspect": "1.3.0",
-            "resolve": "1.4.0",
-            "resumer": "0.0.0",
-            "string.prototype.trim": "1.1.2",
-            "through": "2.3.8"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true
-            }
-          }
-        },
         "tar": {
           "version": "2.2.1",
           "bundled": true,
@@ -10709,22 +10568,18 @@
           "version": "3.4.0",
           "bundled": true,
           "requires": {
-            "debug": "2.6.8",
+            "debug": "2.6.9",
             "fstream": "1.0.11",
             "fstream-ignore": "1.0.5",
             "once": "1.4.0",
             "readable-stream": "2.3.3",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "tar": "2.2.1",
             "uid-number": "0.0.6"
           }
         },
-        "through": {
-          "version": "2.3.8",
-          "bundled": true
-        },
         "tough-cookie": {
-          "version": "2.3.2",
+          "version": "2.3.3",
           "bundled": true,
           "requires": {
             "punycode": "1.4.1"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "JSONStream": "^1.3.1",
     "sequelize": "^3.30.2",
     "sequelize-cli": "^2.5.1",
-    "sqlite3": "3.1.10"
+    "sqlite3": "3.1.13"
   }
 }


### PR DESCRIPTION
* bump sqlite3 to v3.1.13
* ABCM should now run on the latest nodejs version (tested on both node v6.12.3 and latest v9.5

Signed-off-by: Steven Esser <sesser@nexb.com>