### PR TITLE
Add default "All" value to column filters

### DIFF
--- a/assets/app/js/controllers/aboutCodeClueDataTable.js
+++ b/assets/app/js/controllers/aboutCodeClueDataTable.js
@@ -295,7 +295,7 @@ class AboutCodeClueDataTable extends Controller {
       const footer = $(column.footer());
       const columnName = columnInfo.name;
 
-      $(`<select id="clue-${columnName}"><option value=""></option></select>`)
+      $(`<select id="clue-${columnName}"><option value="">All</option></select>`)
         .appendTo(footer)
         .on('click', () => {
           const currPath = pathCol.search()[0];
@@ -326,7 +326,7 @@ class AboutCodeClueDataTable extends Controller {
 
               select
                 .empty()
-                .append(`<option value=""></option>`);
+                .append(`<option value="">All</option>`);
 
               /**
                          * Add Has a Value option to dropdown menu to show all rows


### PR DESCRIPTION
* The string "All" is now the default text for the unfiltered option in
  our Clues table column filters.

* Changes made to how filter values are populated

Addresses: #251